### PR TITLE
fix: '*-dec-{r,g,b}' missing decimal points

### DIFF
--- a/tinted-builder/src/template.rs
+++ b/tinted-builder/src/template.rs
@@ -67,9 +67,18 @@ impl Template {
             context.insert(format!("{}-rgb-r", name), rgb.0.to_string());
             context.insert(format!("{}-rgb-g", name), rgb.1.to_string());
             context.insert(format!("{}-rgb-b", name), rgb.2.to_string());
-            context.insert(format!("{}-dec-r", name), (rgb.0 / 255).to_string());
-            context.insert(format!("{}-dec-g", name), (rgb.1 / 255).to_string());
-            context.insert(format!("{}-dec-b", name), (rgb.2 / 255).to_string());
+            context.insert(
+                format!("{}-dec-r", name),
+                format!("{:.8}", rgb.0 as f64 / 255.),
+            );
+            context.insert(
+                format!("{}-dec-g", name),
+                format!("{:.8}", rgb.1 as f64 / 255.),
+            );
+            context.insert(
+                format!("{}-dec-b", name),
+                format!("{:.8}", rgb.2 as f64 / 255.),
+            );
         }
 
         context

--- a/tinted-builder/tests/general.rs
+++ b/tinted-builder/tests/general.rs
@@ -114,3 +114,39 @@ fn with_nested_sections() -> Result<()> {
     assert_eq!(output, "#cfad25");
     Ok(())
 }
+
+#[test]
+fn render_hex() -> Result<()> {
+    let template_source = "{{base0A-hex}}";
+    let template = Template::new(template_source.to_string())?;
+    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+
+    let output = template.render(&scheme)?;
+
+    assert_eq!(output, "cfad25");
+    Ok(())
+}
+
+#[test]
+fn render_rgb() -> Result<()> {
+    let template_source = "{{base0A-rgb-r}} {{base0A-rgb-g}} {{base0A-rgb-b}}";
+    let template = Template::new(template_source.to_string())?;
+    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+
+    let output = template.render(&scheme)?;
+
+    assert_eq!(output, "207 173 37");
+    Ok(())
+}
+
+#[test]
+fn render_dec() -> Result<()> {
+    let template_source = "{{base0A-dec-r}} {{base0A-dec-g}} {{base0A-dec-b}}";
+    let template = Template::new(template_source.to_string())?;
+    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+
+    let output = template.render(&scheme)?;
+
+    assert_eq!(output, "0.81176471 0.67843137 0.14509804");
+    Ok(())
+}


### PR DESCRIPTION
The decimal points of the `{}-dec-r/g/b` are missing when rendering the template because you are doing an integer division. To fix, I cast to float before dividing and truncate the float to the 8th decimal for consistency with the `go` builder.