### PR TITLE
fix: update gh action to v0.9.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Build all the schemes for a base16 or tinted repo'
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/tinted-theming/tinted-builder-rust:v0.9.1'
+  image: 'docker://ghcr.io/tinted-theming/tinted-builder-rust:v0.9.5'
   args:
     - build
     - .


### PR DESCRIPTION
When using the gh action:
```
...
      - name: "Update schemes"
        uses: "tinted-theming/tinted-builder-rust@v0.9.5"
...
```

I'm still getting the missing decimals, I'm guessing it is because the version in the `action.yml` file was not updated to `v0.9.5`?