### PR TITLE
Restructure library to easily support adding a new scheme system variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ## Changed
 
+- Breaking change: `tinted-builder` library includes an API change and
+  `tinted-builder-rust` now exports the new `tinted-builder` API
 - Breaking change: Use `SchemeSystem` and `SchemeVariant` enums for
   scheme `system` and `variant` properties respectively instead of using
   string values
+
+## Removed
+
+- Remove deprecated `render_to_file` `Template` method
 
 ## [0.9.5] - 2024-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+
+- Breaking change: Use `SchemeSystem` and `SchemeVariant` enums for
+  scheme `system` and `variant` properties respectively instead of using
+  string values
+
 ## [0.9.5] - 2024-08-24
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,18 +303,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -352,18 +362,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -377,11 +387,13 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "quick-xml",
  "regex",
  "ribboncurls",
  "serde",
  "serde_yaml",
  "strip-ansi-escapes",
+ "thiserror",
  "unicode-normalization",
 ]
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,11 @@ use std::fs::read_to_string;
 
 let template_str = read_to_string("path/to/template.mustache").unwrap();
 let scheme_str = read_to_string("path/to/scheme.yml").unwrap();
-
-let template = Template::new(template_str).unwrap();
-let scheme: Scheme = serde_yaml::from_str(&scheme_str).unwrap();
+let scheme = Scheme::Base16(serde_yaml::from_str(&scheme_str).unwrap());
+let template = Template::new(template_str, scheme);
 
 template
-    .render_to_file("path/to/rendered/template", &scheme)
+    .render()
     .unwrap();
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,15 @@ The Scheme struct is as follows:
 
 ```rust
 use std::collections::HashMap;
+use tinted_builder::{SchemeSystem, SchemeVariant};
 
 pub struct Scheme {
-    pub system: String,
+    pub system: SchemeSystem,
     pub name: String,
     pub slug: String,
     pub author: String,
     pub description: Option<String>,
-    pub variant: String,
+    pub variant: SchemeVariant,
     pub palette: HashMap<String, Color>,
 }
 

--- a/tinted-builder-rust/README.md
+++ b/tinted-builder-rust/README.md
@@ -42,7 +42,7 @@ Download the relevant binary from the [repository releases] page.
 
 ## Basic Usage
 
-```shell
+```sh
 tinted-builder-rust sync # To sync with latest schemes
 tinted-builder-rust build path/to/base16-template
 ```

--- a/tinted-builder-rust/src/lib.rs
+++ b/tinted-builder-rust/src/lib.rs
@@ -1,7 +1,8 @@
 // With the new split of tinted-builder-rust (cli) and
-// tinted-builder (lib), tinted-builder is exported here for bakward
+// tinted-builder (lib), tinted-builder is exported here for backward
 // compatibility for a time. Everyone should move to using
 // tinted-builder as the rust library.
+#[doc = include_str!("../README.md")]
 
 mod operations {
     pub mod build;
@@ -10,8 +11,7 @@ mod utils;
 
 pub use crate::operations::build as operation_build;
 
-/// # Add tinted-builder library test since tinted-builder-rust is
-/// exporting the structs
+/// Add tinted-builder library test since tinted-builder-rust is exporting the structs
 ///
 /// ```
 /// use tinted_builder_rust::{Scheme, Template};
@@ -40,15 +40,14 @@ pub use crate::operations::build as operation_build;
 ///   base0D: "6a9eb5"
 ///   base0E: "78a38f"
 ///   base0F: "a3a079""#;
-/// let template = Template::new(template).unwrap();
-/// let scheme: Scheme = serde_yaml::from_str(&scheme_str).unwrap();
+/// let scheme = Scheme::Base16(serde_yaml::from_str(&scheme_str).unwrap());
+/// let template = Template::new(template, scheme);
 /// let output = template
-///     .render(&scheme)
+///     .render()
 ///     .unwrap();
 ///
 ///  assert_eq!(output, r#"/* Some CSS file with UwUnicorn theme */
 /// .someCssSelector { background-color: #241b26 }
 /// .someOtherCssSelector { background-color: #a3a079 }"#);
 /// ```
-pub use tinted_builder::Scheme;
-pub use tinted_builder::Template;
+pub use tinted_builder::{Base16Scheme, Scheme, Template, TintedBuilderError};

--- a/tinted-builder-rust/tests/operation_build.rs
+++ b/tinted-builder-rust/tests/operation_build.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::fs;
 use std::path::PathBuf;
 
@@ -23,10 +23,22 @@ fn setup(system: &str, scheme_name: &str) -> Result<(String, String, String, Str
     ));
 
     Ok((
-        fs::read_to_string(config_file_path)?,
-        fs::read_to_string(scheme_file_path)?,
-        fs::read_to_string(template_file_path)?,
-        fs::read_to_string(template_rendered_path_fixture)?,
+        fs::read_to_string(&config_file_path).context(format!(
+            "Unable to get contents of config: {}",
+            config_file_path.display()
+        ))?,
+        fs::read_to_string(&scheme_file_path).context(format!(
+            "Unable to get contents of scheme: {}",
+            scheme_file_path.display()
+        ))?,
+        fs::read_to_string(&template_file_path).context(format!(
+            "Unable to get contents of template: {}",
+            template_file_path.display()
+        ))?,
+        fs::read_to_string(&template_rendered_path_fixture).context(format!(
+            "Unable to get contents of rendered file: {}",
+            template_rendered_path_fixture.display()
+        ))?,
     ))
 }
 

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 ## Unreleased
 
+## Added
+
+- Add basic documentation for docs.rs
+
 ## Changed
 
+- Require schemes to be wrapped in `Scheme` enum when creating a
+  `Template` struct instance to easily extend builder to support
+  different scheme systems
 - Use `SchemeSystem` and `SchemeVariant` enums for scheme `system` and
   `variant` properties respectively instead of using string values
+
+## Removed
+
+- `anyhow` crate moved to dev-dependency for tests, but replaced with
+  `TintedBuilderError` enum with `thiserror` macros in API
 
 ## 0.5.1 - 2024-08-24
 

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+
+- Use `SchemeSystem` and `SchemeVariant` enums for scheme `system` and
+  `variant` properties respectively instead of using string values
+
 ## 0.5.1 - 2024-08-24
 
 ## Fixed

--- a/tinted-builder/Cargo.toml
+++ b/tinted-builder/Cargo.toml
@@ -13,14 +13,16 @@ categories = ["command-line-utilities", "template-engine"]
 rust-version = "1.74.0"
 
 [dependencies]
-anyhow = "1.0.80"
 clap = "4.5.2"
 dirs = "5.0.1"
+quick-xml = { version = "0.36.1", features = ["serialize"] }
 regex = "1.10.4"
 ribboncurls = "0.2.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.32"
+thiserror = "1.0.63"
 unicode-normalization = "0.1.23"
 
 [dev-dependencies]
+anyhow = "1.0.86"
 strip-ansi-escapes = "0.2.0"

--- a/tinted-builder/README.md
+++ b/tinted-builder/README.md
@@ -48,10 +48,10 @@ palette:
   base0D: "6a9eb5"
   base0E: "78a38f"
   base0F: "a3a079""#;
-let template = Template::new(template).unwrap();
-let scheme: Scheme = serde_yaml::from_str(&scheme_str).unwrap();
+let scheme = Scheme::Base16(serde_yaml::from_str(&scheme_str).unwrap());
+let template = Template::new(template, scheme);
 let output = template
-  .render(&scheme)
+  .render()
   .unwrap();
 
   assert_eq!(output, r#"/* Some CSS file with UwUnicorn theme */
@@ -59,36 +59,18 @@ let output = template
 .someOtherCssSelector { background-color: #a3a079 }"#);
 ```
 
-The Scheme struct is as follows:
-
-```rust
-use std::collections::HashMap;
-use tinted_builder::{SchemeSystem, SchemeVariant};
-
-pub struct Scheme {
-    pub system: SchemeSystem,
-    pub name: String,
-    pub slug: String,
-    pub author: String,
-    pub description: Option<String>,
-    pub variant: SchemeVariant,
-    pub palette: HashMap<String, Color>,
-}
-
-pub struct Color {
-    pub hex: (String, String, String),
-    pub rgb: (u8, u8, u8),
-    pub dec: (f32, f32, f32),
-}
-```
-
-`Template::new`
-The `Template` struct simply sets the content provided to it via
-`Template::new`.
-
-`template.render(&scheme)` takes the scheme, generates the variables
-defined in the `0.11.0` [builder specification] and returns a new
-string.
+1. Create a scheme (`Scheme`) enum variant while providing the
+   deserialized data into into the variant:
+   `Scheme::Base16(serde_yaml::from_str(&scheme_str).unwrap())` in this
+   case
+2. Create a template by passing the serialized mustache text and the
+   `Scheme` variant in step 1 into the `Template` struct:
+   `Template::new(mustache_text, scheme)`. The `template.render()`
+   method takes the scheme, generates the variables defined in the 
+   `0.11.0` [builder specification] and returns a new string.
+3. Render the template by running a method which returns a
+   `Result<String, TintedBuilderError>` type: 
+   `let output = template.render().unwrap();`
 
 ## Contributing
 

--- a/tinted-builder/README.md
+++ b/tinted-builder/README.md
@@ -63,14 +63,15 @@ The Scheme struct is as follows:
 
 ```rust
 use std::collections::HashMap;
+use tinted_builder::{SchemeSystem, SchemeVariant};
 
 pub struct Scheme {
-    pub system: String,
+    pub system: SchemeSystem,
     pub name: String,
     pub slug: String,
     pub author: String,
     pub description: Option<String>,
-    pub variant: String,
+    pub variant: SchemeVariant,
     pub palette: HashMap<String, Color>,
 }
 

--- a/tinted-builder/src/constants.rs
+++ b/tinted-builder/src/constants.rs
@@ -1,9 +1,0 @@
-pub(crate) const REQUIRED_BASE16_PALETTE_KEYS: [&str; 16] = [
-    "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
-    "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F",
-];
-pub(crate) const REQUIRED_BASE24_PALETTE_KEYS: [&str; 24] = [
-    "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
-    "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F", "base10", "base11",
-    "base12", "base13", "base14", "base15", "base16", "base17",
-];

--- a/tinted-builder/src/error.rs
+++ b/tinted-builder/src/error.rs
@@ -1,0 +1,53 @@
+use ribboncurls::RibboncurlsError;
+use thiserror::Error;
+
+/// An error type representing the various errors that can occur when using tinted-builder
+///
+/// This error type is non-exhaustive, meaning additional variants may be added in future versions without
+/// it being considered a breaking change. The enum variants cover a range of possible issues that might
+/// arise during the processing of color schemes, including missing properties, deserialization errors,
+/// and rendering issues.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum TintedBuilderError {
+    /// Error indicating that a required property in the scheme is missing.
+    ///
+    /// This variant is used when a necessary property for the scheme's configuration is not found.
+    #[error("missing scheme property: {0}")]
+    SchemeMissingProperty(String),
+
+    /// Error that occurs when YAML deserialization fails.
+    ///
+    /// This variant wraps the `serde_yaml::Error` and is used when there is an issue converting
+    /// a YAML string into the corresponding Rust data structure.
+    #[error("unable to deserialize yaml")]
+    YamlDeserialize(#[from] serde_yaml::Error),
+
+    /// Error that occurs during rendering using Ribboncurls.
+    ///
+    /// This variant wraps the `RibboncurlsError` and is used when an error is encountered while
+    /// rendering a template or other content using Ribboncurls.
+    #[error("unable to render")]
+    RibboncurlsRender(#[from] RibboncurlsError),
+
+    /// Error that occurs when a string slice cannot be converted to an integer with the given base.
+    ///
+    /// This variant wraps `std::num::ParseIntError` and is used when a string slice, such as a color
+    /// value in hexadecimal format, fails to parse correctly.
+    #[error("unable to convert string slice to integer with given base")]
+    ColorRadix(#[from] std::num::ParseIntError),
+
+    /// Error indicating that a hex color input is not formatted correctly.
+    ///
+    /// This variant is used when a color string that is expected to be in hex format does not match
+    /// the expected format.
+    #[error("hex input is not formatted correctly")]
+    HexInputFormat,
+
+    /// Error indicating that an invalid scheme variant was provided.
+    ///
+    /// This variant is used when an input string does not correspond to any valid scheme variant,
+    /// such as "dark" or "light".
+    #[error("invalid scheme variant: {0}")]
+    InvalidSchemeVariant(String),
+}

--- a/tinted-builder/src/lib.rs
+++ b/tinted-builder/src/lib.rs
@@ -1,7 +1,9 @@
 #[doc = include_str!("../README.md")]
-mod constants;
+mod error;
 mod scheme;
 mod template;
+mod utils;
 
-pub use scheme::{Color, Scheme, SchemeSystem, SchemeVariant};
+pub use error::TintedBuilderError;
+pub use scheme::{Base16Scheme, Color, Scheme, SchemeSystem, SchemeVariant};
 pub use template::Template;

--- a/tinted-builder/src/lib.rs
+++ b/tinted-builder/src/lib.rs
@@ -3,5 +3,5 @@ mod constants;
 mod scheme;
 mod template;
 
-pub use scheme::{Color, Scheme};
+pub use scheme::{Color, Scheme, SchemeSystem, SchemeVariant};
 pub use template::Template;

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -1,46 +1,40 @@
+mod base16;
 mod color;
 
-use regex::Regex;
-use serde::ser::{SerializeMap, SerializeStruct};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{collections::HashMap, fmt};
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
 
-use crate::constants::{REQUIRED_BASE16_PALETTE_KEYS, REQUIRED_BASE24_PALETTE_KEYS};
-
+pub use crate::scheme::base16::Base16Scheme;
 pub use crate::scheme::color::Color;
+use crate::TintedBuilderError;
 
-#[derive(Deserialize, Serialize)]
-pub struct SchemeWrapper {
-    pub(crate) system: SchemeSystem,
-    pub(crate) name: String,
-    pub(crate) slug: Option<String>,
-    pub(crate) author: String,
-    pub(crate) description: Option<String>,
-    pub(crate) variant: Option<SchemeVariant>,
-    pub(crate) palette: HashMap<String, String>,
+/// Enum representing schemes for different scheme systems. This enum is non-exhaustive, meaning
+/// additional variants may be added in future versions without it being considered a breaking
+/// change.
+#[non_exhaustive]
+pub enum Scheme {
+    /// Base16 variant with Base16Scheme deserialized content.
+    Base16(Base16Scheme),
+    /// Base24 variant with Base16Scheme deserialized content. Base16Scheme is built to support
+    /// basic supersets of Base16 schemes.
+    Base24(Base16Scheme),
 }
 
-#[derive(Debug, Clone)]
-pub struct Scheme {
-    pub system: SchemeSystem,
-    pub name: String,
-    pub slug: String,
-    pub author: String,
-    pub description: Option<String>,
-    pub variant: SchemeVariant,
-    pub palette: HashMap<String, Color>,
-}
-
+/// Enum representing the scheme system. This enum is non-exhaustive, meaning additional variants
+/// may be added in future versions without it being considered a breaking change.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SchemeSystem {
+    /// Base16 scheme system, the default.
     #[default]
     Base16,
+    /// Base24 scheme system.
     Base24,
 }
 
 impl SchemeSystem {
+    /// Returns the string representation of the `SchemeSystem`.
     pub fn as_str(&self) -> &str {
         match self {
             SchemeSystem::Base16 => "base16",
@@ -57,16 +51,42 @@ impl fmt::Display for SchemeSystem {
     }
 }
 
+/// Enum representing variants of a color scheme, such as Dark or Light. This enum is
+/// non-exhaustive, meaning additional variants may be added in future versions without it being
+/// considered a breaking change.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SchemeVariant {
+    /// Dark variant of the color scheme, the default.
     #[default]
     Dark,
+    /// Light variant of the color scheme.
     Light,
 }
 
+impl FromStr for SchemeVariant {
+    type Err = TintedBuilderError;
+
+    /// Parses a string to create a `SchemeVariant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TintedBuilderError` if the input string does not match
+    /// any valid scheme variant.
+    fn from_str(variant_str: &str) -> Result<Self, Self::Err> {
+        match variant_str {
+            "light" => Ok(Self::Light),
+            "dark" => Ok(Self::Dark),
+            _ => Err(TintedBuilderError::InvalidSchemeVariant(
+                variant_str.to_string(),
+            )),
+        }
+    }
+}
+
 impl SchemeVariant {
+    /// Returns the string representation of the `SchemeVariant`.
     pub fn as_str(&self) -> &str {
         match self {
             SchemeVariant::Dark => "dark",
@@ -80,206 +100,5 @@ impl fmt::Display for SchemeVariant {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())?;
         Ok(())
-    }
-}
-
-impl fmt::Display for Scheme {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "author: \"{}\"", self.author)?;
-        if let Some(ref desc) = self.description {
-            writeln!(f, "description: \"{}\"", desc)?;
-        }
-        writeln!(f, "name: \"{}\"", self.name)?;
-        writeln!(f, "slug: \"{}\"", self.slug)?;
-        writeln!(f, "system: \"{}\"", self.system)?;
-        writeln!(f, "variant: \"{}\"", self.variant)?;
-        writeln!(f, "palette:")?;
-
-        let mut palette_vec: Vec<(String, Color)> = self
-            .palette
-            .clone()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect();
-        palette_vec.sort_by_key(|k| k.0.clone());
-
-        for (key, value) in palette_vec {
-            writeln!(f, "  {}: \"{}\"", key, value)?;
-        }
-        Ok(())
-    }
-}
-
-pub(crate) fn slugify(input: &str) -> String {
-    let char_map: HashMap<char, &str> = [
-        ('á', "a"),
-        ('à', "a"),
-        ('â', "a"),
-        ('ä', "a"),
-        ('ã', "a"),
-        ('å', "a"),
-        ('æ', "ae"),
-        ('ç', "c"),
-        ('é', "e"),
-        ('è', "e"),
-        ('ê', "e"),
-        ('ë', "e"),
-        ('í', "i"),
-        ('ì', "i"),
-        ('î', "i"),
-        ('ï', "i"),
-        ('ł', "l"),
-        ('ñ', "n"),
-        ('ń', "n"),
-        ('ó', "o"),
-        ('ò', "o"),
-        ('ô', "o"),
-        ('ö', "o"),
-        ('õ', "o"),
-        ('ø', "o"),
-        ('œ', "oe"),
-        ('ś', "s"),
-        ('ú', "u"),
-        ('ù', "u"),
-        ('û', "u"),
-        ('ü', "u"),
-        ('ý', "y"),
-        ('ÿ', "y"),
-        ('ż', "z"),
-        ('ź', "z"),
-        ('š', "s"),
-        ('č', "c"),
-        ('ř', "r"),
-        ('đ', "d"),
-        ('ß', "ss"),
-        ('þ', "th"),
-        ('ħ', "h"),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    let mut slug = String::new();
-    for c in input.to_lowercase().chars() {
-        match c {
-            'a'..='z' | '0'..='9' => slug.push(c),
-            ' ' | '-' | '_' => slug.push('-'),
-            _ => {
-                if let Some(replacement) = char_map.get(&c) {
-                    slug.push_str(replacement);
-                }
-            }
-        }
-    }
-
-    let re = Regex::new(r"-+").expect("Unable to unwrap regex");
-    let cleaned_slug = re.replace_all(&slug, "-").to_string();
-
-    cleaned_slug.trim_matches('-').to_string()
-}
-
-impl<'de> Deserialize<'de> for Scheme {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let wrapper = SchemeWrapper::deserialize(deserializer)?;
-        let slug = wrapper
-            .slug
-            .map_or(slugify(&wrapper.name), |slug| slugify(&slug));
-        let variant = wrapper.variant.unwrap_or(SchemeVariant::Dark);
-
-        match wrapper.system.as_str() {
-            "base16" => {
-                let contains_all_keys = REQUIRED_BASE16_PALETTE_KEYS
-                    .iter()
-                    .all(|&key| wrapper.palette.contains_key(key));
-
-                if !contains_all_keys {
-                    return Err(serde::de::Error::custom(format!(
-                        "{} scheme does not contain the required palette properties",
-                        wrapper.system
-                    )));
-                }
-            }
-            "base24" => {
-                let contains_all_keys = REQUIRED_BASE24_PALETTE_KEYS
-                    .iter()
-                    .all(|&key| wrapper.palette.contains_key(key));
-
-                if !contains_all_keys {
-                    return Err(serde::de::Error::custom(format!(
-                        "{} scheme does not contain the required palette properties",
-                        wrapper.system
-                    )));
-                }
-            }
-            _ => {
-                return Err(serde::de::Error::custom(format!(
-                    "Unknown system: {}",
-                    wrapper.system
-                )))
-            }
-        }
-
-        let palette_result: Result<HashMap<String, Color>, _> = wrapper
-            .palette
-            .into_iter()
-            .map(|(key, value)| {
-                Color::new(value)
-                    .map(|color| (key, color))
-                    .map_err(|e| serde::de::Error::custom(e.to_string()))
-            })
-            .collect();
-
-        Ok(Scheme {
-            name: wrapper.name,
-            slug,
-            system: wrapper.system,
-            author: wrapper.author,
-            description: wrapper.description,
-            variant,
-            palette: palette_result?,
-        })
-    }
-}
-
-impl Serialize for Scheme {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Scheme", 7)?;
-        state.serialize_field("system", &self.system)?;
-        state.serialize_field("name", &self.name)?;
-        state.serialize_field("slug", &self.slug)?;
-        state.serialize_field("author", &self.author)?;
-        state.serialize_field("description", &self.description)?;
-        state.serialize_field("variant", &self.variant)?;
-
-        // Collect and sort the palette by key
-        let mut sorted_palette: Vec<(&String, &Color)> = self.palette.iter().collect();
-        sorted_palette.sort_by(|a, b| a.0.cmp(b.0));
-
-        // Serialize the sorted palette as a map within the struct
-        state.serialize_field("palette", &SortedPalette(sorted_palette))?;
-
-        state.end()
-    }
-}
-
-// Helper struct for serializing sorted palette
-struct SortedPalette<'a>(Vec<(&'a String, &'a Color)>);
-
-impl<'a> Serialize for SortedPalette<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(self.0.len()))?;
-        for (key, value) in &self.0 {
-            map.serialize_entry(key, &value.to_hex())?;
-        }
-        map.end()
     }
 }

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -11,24 +11,76 @@ pub use crate::scheme::color::Color;
 
 #[derive(Deserialize, Serialize)]
 pub struct SchemeWrapper {
-    pub(crate) system: String,
+    pub(crate) system: SchemeSystem,
     pub(crate) name: String,
     pub(crate) slug: Option<String>,
     pub(crate) author: String,
     pub(crate) description: Option<String>,
-    pub(crate) variant: Option<String>,
+    pub(crate) variant: Option<SchemeVariant>,
     pub(crate) palette: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Scheme {
-    pub system: String,
+    pub system: SchemeSystem,
     pub name: String,
     pub slug: String,
     pub author: String,
     pub description: Option<String>,
-    pub variant: String,
+    pub variant: SchemeVariant,
     pub palette: HashMap<String, Color>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemeSystem {
+    #[default]
+    Base16,
+    Base24,
+}
+
+impl SchemeSystem {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SchemeSystem::Base16 => "base16",
+            SchemeSystem::Base24 => "base24",
+        }
+    }
+}
+
+impl fmt::Display for SchemeSystem {
+    /// Formats the `SchemeSystem` for display purposes.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())?;
+        Ok(())
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemeVariant {
+    #[default]
+    Dark,
+    Light,
+}
+
+impl SchemeVariant {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SchemeVariant::Dark => "dark",
+            SchemeVariant::Light => "light",
+        }
+    }
+}
+
+impl fmt::Display for SchemeVariant {
+    /// Formats the `SchemeVariant` for display purposes.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())?;
+        Ok(())
+    }
 }
 
 impl fmt::Display for Scheme {
@@ -135,7 +187,7 @@ impl<'de> Deserialize<'de> for Scheme {
         let slug = wrapper
             .slug
             .map_or(slugify(&wrapper.name), |slug| slugify(&slug));
-        let variant = wrapper.variant.unwrap_or(String::from("dark"));
+        let variant = wrapper.variant.unwrap_or(SchemeVariant::Dark);
 
         match wrapper.system.as_str() {
             "base16" => {

--- a/tinted-builder/src/scheme/base16.rs
+++ b/tinted-builder/src/scheme/base16.rs
@@ -1,0 +1,167 @@
+use serde::ser::{SerializeMap, SerializeStruct};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::HashMap, fmt};
+
+pub use crate::scheme::color::Color;
+
+use crate::{utils::slugify, SchemeSystem, SchemeVariant};
+
+pub(crate) const REQUIRED_BASE16_PALETTE_KEYS: [&str; 16] = [
+    "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
+    "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F",
+];
+
+pub(crate) const REQUIRED_BASE24_PALETTE_KEYS: [&str; 24] = [
+    "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
+    "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F", "base10", "base11",
+    "base12", "base13", "base14", "base15", "base16", "base17",
+];
+
+#[derive(Deserialize, Serialize)]
+struct SchemeWrapper {
+    pub(crate) system: SchemeSystem,
+    pub(crate) name: String,
+    pub(crate) slug: Option<String>,
+    pub(crate) author: String,
+    pub(crate) description: Option<String>,
+    pub(crate) variant: Option<SchemeVariant>,
+    pub(crate) palette: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Base16Scheme {
+    pub system: SchemeSystem,
+    pub name: String,
+    pub slug: String,
+    pub author: String,
+    pub description: Option<String>,
+    pub variant: SchemeVariant,
+    pub palette: HashMap<String, Color>,
+}
+
+impl fmt::Display for Base16Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "author: \"{}\"", self.author)?;
+        if let Some(ref desc) = self.description {
+            writeln!(f, "description: \"{}\"", desc)?;
+        }
+        writeln!(f, "name: \"{}\"", self.name)?;
+        writeln!(f, "slug: \"{}\"", self.slug)?;
+        writeln!(f, "system: \"{}\"", self.system)?;
+        writeln!(f, "variant: \"{}\"", self.variant)?;
+        writeln!(f, "palette:")?;
+
+        let mut palette_vec: Vec<(String, Color)> = self
+            .palette
+            .clone()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+        palette_vec.sort_by_key(|k| k.0.clone());
+
+        for (key, value) in palette_vec {
+            writeln!(f, "  {}: \"{}\"", key, value)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for Base16Scheme {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wrapper = SchemeWrapper::deserialize(deserializer)?;
+        let slug = wrapper
+            .slug
+            .map_or(slugify(&wrapper.name), |slug| slugify(&slug));
+        let variant = wrapper.variant.unwrap_or(SchemeVariant::Dark);
+
+        match wrapper.system {
+            SchemeSystem::Base16 => {
+                let contains_all_keys = REQUIRED_BASE16_PALETTE_KEYS
+                    .iter()
+                    .all(|&key| wrapper.palette.contains_key(key));
+
+                if !contains_all_keys {
+                    return Err(serde::de::Error::custom(format!(
+                        "{} scheme does not contain the required palette properties",
+                        wrapper.system
+                    )));
+                }
+            }
+            SchemeSystem::Base24 => {
+                let contains_all_keys = REQUIRED_BASE24_PALETTE_KEYS
+                    .iter()
+                    .all(|&key| wrapper.palette.contains_key(key));
+
+                if !contains_all_keys {
+                    return Err(serde::de::Error::custom(format!(
+                        "{} scheme does not contain the required palette properties",
+                        wrapper.system
+                    )));
+                }
+            }
+        }
+
+        let palette_result: Result<HashMap<String, Color>, _> = wrapper
+            .palette
+            .into_iter()
+            .map(|(key, value)| {
+                Color::new(value)
+                    .map(|color| (key, color))
+                    .map_err(|e| serde::de::Error::custom(e.to_string()))
+            })
+            .collect();
+
+        Ok(Base16Scheme {
+            name: wrapper.name,
+            slug,
+            system: wrapper.system,
+            author: wrapper.author,
+            description: wrapper.description,
+            variant,
+            palette: palette_result?,
+        })
+    }
+}
+
+impl Serialize for Base16Scheme {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Scheme", 7)?;
+        state.serialize_field("system", &self.system)?;
+        state.serialize_field("name", &self.name)?;
+        state.serialize_field("slug", &self.slug)?;
+        state.serialize_field("author", &self.author)?;
+        state.serialize_field("description", &self.description)?;
+        state.serialize_field("variant", &self.variant)?;
+
+        // Collect and sort the palette by key
+        let mut sorted_palette: Vec<(&String, &Color)> = self.palette.iter().collect();
+        sorted_palette.sort_by(|a, b| a.0.cmp(b.0));
+
+        // Serialize the sorted palette as a map within the struct
+        state.serialize_field("palette", &SortedPalette(sorted_palette))?;
+
+        state.end()
+    }
+}
+
+// Helper struct for serializing sorted palette
+struct SortedPalette<'a>(Vec<(&'a String, &'a Color)>);
+
+impl<'a> Serialize for SortedPalette<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (key, value) in &self.0 {
+            map.serialize_entry(key, &value.to_hex())?;
+        }
+        map.end()
+    }
+}

--- a/tinted-builder/src/scheme/color.rs
+++ b/tinted-builder/src/scheme/color.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use anyhow::{anyhow, Context, Result};
+use crate::error::TintedBuilderError;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Color {
@@ -11,16 +11,15 @@ pub struct Color {
 }
 
 impl Color {
-    pub fn new(hex_color: String) -> Result<Color> {
-        let hex_full = process_hex_input(&hex_color)
-            .ok_or_else(|| anyhow::anyhow!("Provided hex value is not formatted correctly"))?;
+    pub fn new(hex_color: String) -> Result<Color, TintedBuilderError> {
+        let hex_full =
+            process_hex_input(&hex_color).ok_or_else(|| TintedBuilderError::HexInputFormat)?;
         let hex: (String, String, String) = (
             hex_full[0..2].to_lowercase(),
             hex_full[2..4].to_lowercase(),
             hex_full[4..6].to_lowercase(),
         );
-        let rgb = hex_to_rgb(&hex)
-            .map_err(|_| anyhow!("Unable to convert hex value to rgb: {}", hex_full))?;
+        let rgb = hex_to_rgb(&hex)?;
         let dec: (f32, f32, f32) = (
             rgb.0 as f32 / 255.0,
             rgb.1 as f32 / 255.0,
@@ -41,13 +40,10 @@ impl fmt::Display for Color {
     }
 }
 
-fn hex_to_rgb(hex: &(String, String, String)) -> Result<(u8, u8, u8)> {
-    let r = u8::from_str_radix(hex.0.as_str(), 16)
-        .context("Invalid hex character for red component")?;
-    let g = u8::from_str_radix(hex.1.as_str(), 16)
-        .context("Invalid hex character for green component")?;
-    let b = u8::from_str_radix(hex.2.as_str(), 16)
-        .context("Invalid hex character for blue component")?;
+fn hex_to_rgb(hex: &(String, String, String)) -> Result<(u8, u8, u8), TintedBuilderError> {
+    let r = u8::from_str_radix(hex.0.as_str(), 16)?;
+    let g = u8::from_str_radix(hex.1.as_str(), 16)?;
+    let b = u8::from_str_radix(hex.2.as_str(), 16)?;
 
     Ok((r, g, b))
 }

--- a/tinted-builder/src/template.rs
+++ b/tinted-builder/src/template.rs
@@ -1,112 +1,89 @@
-use anyhow::{Context, Result};
-use std::collections::HashMap;
-use std::fs::{remove_file, File};
-use std::io::Write;
-use std::path::Path;
+mod base16;
 
-use crate::Scheme;
+use crate::{error::TintedBuilderError, scheme::Scheme};
 
+/// A struct representing a template that can be rendered with the provided color scheme.
+///
+/// The `Template` struct holds the content of the template and the scheme used to render it. It
+/// provides methods to create a new template and render it into a `String` using the specified
+/// color scheme.
 pub struct Template {
     content: String,
-}
-
-pub(crate) fn write_to_file(path: &Path, contents: &str) -> Result<()> {
-    if path.exists() {
-        remove_file(path).with_context(|| format!("Unable to remove file: {}", path.display()))?;
-    }
-
-    let mut file =
-        File::create(path).with_context(|| format!("Unable to create file: {}", path.display()))?;
-
-    file.write_all(contents.as_bytes())?;
-
-    Ok(())
+    scheme: Scheme,
 }
 
 impl Template {
-    pub fn new(content: String) -> Result<Template> {
-        Ok(Template { content })
+    /// Creates a new `Template` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `content` - A `String` representing the content of the template.
+    /// * `scheme` - A `Scheme` enum that determines which color scheme to use when rendering the template.
+    ///
+    /// # Returns
+    ///
+    /// A new `Template` instance with the provided content and scheme.
+    pub fn new(content: String, scheme: Scheme) -> Template {
+        Template { content, scheme }
     }
 
-    fn to_template_context(scheme: &Scheme) -> HashMap<String, String> {
-        let mut context = HashMap::new();
+    /// Renders the template into a `String` using the provided color scheme.
+    ///
+    /// This method applies the specified `Scheme` to the template content, converting placeholders
+    /// in the content to their corresponding values from the scheme context.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TintedBuilderError` if the rendering process fails. This could happen if the
+    /// content contains placeholders that cannot be resolved using the scheme context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tinted_builder::{Template, Scheme};
+    ///
+    /// let scheme_yaml = r#"
+    /// system: "base16"
+    /// name: "Some name"
+    /// author: "Some author"
+    /// variant: "dark"
+    /// palette:
+    ///   base00: "241b26"
+    ///   base01: "2f2a3f"
+    ///   base02: "46354a"
+    ///   base03: "6c3cb2"
+    ///   base04: "7e5f83"
+    ///   base05: "eed5d9"
+    ///   base06: "d9c2c6"
+    ///   base07: "e4ccd0"
+    ///   base08: "877bb6"
+    ///   base09: "de5b44"
+    ///   base0A: "a84a73"
+    ///   base0B: "c965bf"
+    ///   base0C: "9c5fce"
+    ///   base0D: "6a9eb5"
+    ///   base0E: "78a38f"
+    ///   base0F: "a3a079"
+    /// "#;
+    /// let template = Template::new(
+    ///     r#"{{scheme-system}} scheme name is "{{scheme-name}}" and first color is #{{base00-hex}}"#.to_string(),
+    ///     Scheme::Base16(serde_yaml::from_str(scheme_yaml).unwrap())
+    /// );
+    /// let rendered = template.render().unwrap();
+    ///
+    /// assert_eq!(
+    ///     rendered,
+    ///     r#"base16 scheme name is "Some name" and first color is #241b26"#
+    /// );
+    /// ```
+    pub fn render(&self) -> Result<String, TintedBuilderError> {
+        match self.scheme {
+            Scheme::Base16(ref scheme) | Scheme::Base24(ref scheme) => {
+                let ctx = base16::to_template_context(&scheme.clone());
+                let rendered = base16::render(&self.content, &ctx)?;
 
-        context.insert("scheme-name".to_string(), scheme.name.clone());
-        context.insert("scheme-author".to_string(), scheme.author.clone());
-        context.insert(
-            "scheme-description".to_string(),
-            scheme.description.clone().unwrap_or_default(),
-        );
-        context.insert("scheme-slug".to_string(), scheme.slug.clone());
-        context.insert(
-            "scheme-slug-underscored".to_string(),
-            scheme.slug.replace('-', "_"),
-        );
-        context.insert(
-            "scheme-system".to_string(),
-            scheme.system.as_str().to_string(),
-        );
-        context.insert(
-            "scheme-variant".to_string(),
-            scheme.variant.as_str().to_string(),
-        );
-        context.insert(
-            format!("scheme-is-{}-variant", scheme.variant),
-            "true".to_string(),
-        );
-
-        for (name, color) in scheme.palette.iter() {
-            let hex = color.hex.clone();
-            let rgb = color.rgb;
-
-            context.insert(
-                format!("{}-hex", name),
-                format!("{}{}{}", color.hex.0, color.hex.1, color.hex.2),
-            );
-            context.insert(
-                format!("{}-hex-bgr", name),
-                format!("{}{}{}", color.hex.2, color.hex.1, color.hex.0),
-            );
-            context.insert(format!("{}-hex-r", name), hex.0);
-            context.insert(format!("{}-hex-g", name), hex.1);
-            context.insert(format!("{}-hex-b", name), hex.2);
-            context.insert(format!("{}-rgb-r", name), rgb.0.to_string());
-            context.insert(format!("{}-rgb-g", name), rgb.1.to_string());
-            context.insert(format!("{}-rgb-b", name), rgb.2.to_string());
-            context.insert(
-                format!("{}-dec-r", name),
-                format!("{:.8}", rgb.0 as f64 / 255.),
-            );
-            context.insert(
-                format!("{}-dec-g", name),
-                format!("{:.8}", rgb.1 as f64 / 255.),
-            );
-            context.insert(
-                format!("{}-dec-b", name),
-                format!("{:.8}", rgb.2 as f64 / 255.),
-            );
+                Ok(rendered)
+            }
         }
-
-        context
-    }
-
-    pub fn render(&self, scheme: &Scheme) -> Result<String> {
-        let context = serde_yaml::to_string(&Self::to_template_context(scheme))?;
-        let rendered = ribboncurls::render(&self.content, &context, None)?;
-
-        Ok(rendered)
-    }
-
-    #[deprecated(
-        since = "0.4.0",
-        note = "Please use the `render` method instead and write the output to a file yourself."
-    )]
-    pub fn render_to_file(&self, output_path: &Path, scheme: &Scheme) -> Result<&Self> {
-        let context = serde_yaml::to_string(&Self::to_template_context(scheme))?;
-        let rendered = ribboncurls::render(&self.content, &context, None)?;
-
-        write_to_file(output_path, &rendered)?;
-
-        Ok(self)
     }
 }

--- a/tinted-builder/src/template.rs
+++ b/tinted-builder/src/template.rs
@@ -42,8 +42,14 @@ impl Template {
             "scheme-slug-underscored".to_string(),
             scheme.slug.replace('-', "_"),
         );
-        context.insert("scheme-system".to_string(), scheme.system.clone());
-        context.insert("scheme-variant".to_string(), scheme.variant.clone());
+        context.insert(
+            "scheme-system".to_string(),
+            scheme.system.as_str().to_string(),
+        );
+        context.insert(
+            "scheme-variant".to_string(),
+            scheme.variant.as_str().to_string(),
+        );
         context.insert(
             format!("scheme-is-{}-variant", scheme.variant),
             "true".to_string(),

--- a/tinted-builder/src/template/base16.rs
+++ b/tinted-builder/src/template/base16.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use crate::{error::TintedBuilderError, Base16Scheme};
+
+pub(crate) fn render(
+    content: &str,
+    ctx: &HashMap<String, String>,
+) -> Result<String, TintedBuilderError> {
+    let context = serde_yaml::to_string(&ctx)?;
+    let rendered = ribboncurls::render(content, &context, None)?;
+
+    Ok(rendered)
+}
+
+pub(crate) fn to_template_context(scheme: &Base16Scheme) -> HashMap<String, String> {
+    let mut context = HashMap::new();
+
+    context.insert("scheme-name".to_string(), scheme.name.clone());
+    context.insert("scheme-author".to_string(), scheme.author.clone());
+    context.insert(
+        "scheme-description".to_string(),
+        scheme.description.clone().unwrap_or_default(),
+    );
+    context.insert("scheme-slug".to_string(), scheme.slug.clone());
+    context.insert(
+        "scheme-slug-underscored".to_string(),
+        scheme.slug.replace('-', "_"),
+    );
+    context.insert("scheme-system".to_string(), scheme.system.to_string());
+    context.insert(
+        "scheme-variant".to_string(),
+        scheme.variant.as_str().to_string(),
+    );
+    context.insert(
+        format!("scheme-is-{}-variant", scheme.variant),
+        "true".to_string(),
+    );
+
+    for (name, color) in scheme.palette.iter() {
+        let hex = color.hex.clone();
+        let rgb = color.rgb;
+
+        context.insert(
+            format!("{}-hex", name),
+            format!("{}{}{}", color.hex.0, color.hex.1, color.hex.2),
+        );
+        context.insert(
+            format!("{}-hex-bgr", name),
+            format!("{}{}{}", color.hex.2, color.hex.1, color.hex.0),
+        );
+        context.insert(format!("{}-hex-r", name), hex.0);
+        context.insert(format!("{}-hex-g", name), hex.1);
+        context.insert(format!("{}-hex-b", name), hex.2);
+        context.insert(format!("{}-rgb-r", name), rgb.0.to_string());
+        context.insert(format!("{}-rgb-g", name), rgb.1.to_string());
+        context.insert(format!("{}-rgb-b", name), rgb.2.to_string());
+        context.insert(
+            format!("{}-dec-r", name),
+            format!("{:.8}", rgb.0 as f64 / 255.),
+        );
+        context.insert(
+            format!("{}-dec-g", name),
+            format!("{:.8}", rgb.1 as f64 / 255.),
+        );
+        context.insert(
+            format!("{}-dec-b", name),
+            format!("{:.8}", rgb.2 as f64 / 255.),
+        );
+    }
+
+    context
+}

--- a/tinted-builder/src/utils.rs
+++ b/tinted-builder/src/utils.rs
@@ -1,0 +1,70 @@
+use regex::Regex;
+use std::collections::HashMap;
+
+pub(crate) fn slugify(input: &str) -> String {
+    let char_map: HashMap<char, &str> = [
+        ('á', "a"),
+        ('à', "a"),
+        ('â', "a"),
+        ('ä', "a"),
+        ('ã', "a"),
+        ('å', "a"),
+        ('æ', "ae"),
+        ('ç', "c"),
+        ('é', "e"),
+        ('è', "e"),
+        ('ê', "e"),
+        ('ë', "e"),
+        ('í', "i"),
+        ('ì', "i"),
+        ('î', "i"),
+        ('ï', "i"),
+        ('ł', "l"),
+        ('ñ', "n"),
+        ('ń', "n"),
+        ('ó', "o"),
+        ('ò', "o"),
+        ('ô', "o"),
+        ('ö', "o"),
+        ('õ', "o"),
+        ('ø', "o"),
+        ('œ', "oe"),
+        ('ś', "s"),
+        ('ú', "u"),
+        ('ù', "u"),
+        ('û', "u"),
+        ('ü', "u"),
+        ('ý', "y"),
+        ('ÿ', "y"),
+        ('ż', "z"),
+        ('ź', "z"),
+        ('š', "s"),
+        ('č', "c"),
+        ('ř', "r"),
+        ('đ', "d"),
+        ('ß', "ss"),
+        ('þ', "th"),
+        ('ħ', "h"),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let mut slug = String::new();
+    for c in input.to_lowercase().chars() {
+        match c {
+            'a'..='z' | '0'..='9' => slug.push(c),
+            ' ' | '-' | '_' => slug.push('-'),
+            _ => {
+                if let Some(replacement) = char_map.get(&c) {
+                    slug.push_str(replacement);
+                }
+            }
+        }
+    }
+
+    let re = Regex::new(r"-+").expect("Unable to unwrap regex");
+    let cleaned_slug = re.replace_all(&slug, "-").to_string();
+
+    cleaned_slug.trim_matches('-').to_string()
+}

--- a/tinted-builder/tests/general.rs
+++ b/tinted-builder/tests/general.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tinted_builder::{Scheme, Template};
+use tinted_builder::{Scheme, Template, TintedBuilderError};
 
 const SCHEME_SILK_LIGHT: &str = r##"
 system: "base16"
@@ -51,65 +51,65 @@ palette:
 "#;
 
 #[test]
-fn render_without_content() -> Result<()> {
+fn render_without_content() -> Result<(), TintedBuilderError> {
     let template_source = "Hello!".to_string();
-    let template = Template::new(template_source)?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source, scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "Hello!");
     Ok(())
 }
 
 #[test]
-fn comments() -> Result<()> {
+fn comments() -> Result<(), TintedBuilderError> {
     let template_source =
         r#"<div style="background-color: #{{base09-hex}};">{{ ! some # comment }}</div>"#;
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(&output, r#"<div style="background-color: #d27f46;"></div>"#);
     Ok(())
 }
 
 #[test]
-fn escaped_and_unescaped_vars() -> Result<()> {
+fn escaped_and_unescaped_vars() -> Result<(), TintedBuilderError> {
     let template_source = r#"Author: {{{scheme-author}}}
 Author escaped: {{scheme-author}}"#;
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_CRAZY)?;
     let expected = r#"Author: <a href="https://github.com/Misterio77">Gabriel Fontes</a>
 Author escaped: &lt;a href=&quot;https://github.com/Misterio77&quot;&gt;Gabriel Fontes&lt;/a&gt;"#;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_CRAZY)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, expected);
     Ok(())
 }
 
 #[test]
-fn with_basic_sections() -> Result<()> {
+fn with_basic_sections() -> Result<(), TintedBuilderError> {
     let template_source =
         "Does base17 var exist: {{#base17-hex}}Yes{{/base17-hex}}{{^base17-hex}}No{{/base17-hex}}";
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "Does base17 var exist: No");
     Ok(())
 }
 
 #[test]
-fn with_nested_sections() -> Result<()> {
+fn with_nested_sections() -> Result<(), TintedBuilderError> {
     let template_source = "{{#scheme-author}}{{#scheme-slug}}{{#base0A-hex}}#{{.}}{{/base0A-hex}}{{/scheme-slug}}{{/scheme-author}}";
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "#cfad25");
     Ok(())
@@ -118,10 +118,10 @@ fn with_nested_sections() -> Result<()> {
 #[test]
 fn render_hex() -> Result<()> {
     let template_source = "{{base0A-hex}}";
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "cfad25");
     Ok(())
@@ -130,10 +130,10 @@ fn render_hex() -> Result<()> {
 #[test]
 fn render_rgb() -> Result<()> {
     let template_source = "{{base0A-rgb-r}} {{base0A-rgb-g}} {{base0A-rgb-b}}";
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "207 173 37");
     Ok(())
@@ -142,10 +142,10 @@ fn render_rgb() -> Result<()> {
 #[test]
 fn render_dec() -> Result<()> {
     let template_source = "{{base0A-dec-r}} {{base0A-dec-g}} {{base0A-dec-b}}";
-    let template = Template::new(template_source.to_string())?;
-    let scheme: Scheme = serde_yaml::from_str(SCHEME_SILK_LIGHT)?;
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
 
-    let output = template.render(&scheme)?;
+    let output = template.render()?;
 
     assert_eq!(output, "0.81176471 0.67843137 0.14509804");
     Ok(())


### PR DESCRIPTION
I've been playing around with the idea of adding a new scheme system to tinted-builder but it requires some refactoring to separate Base16 as the default/main system. 

This change allows new scheme systems to be easily added without breaking the API.