### PR TITLE
Release lib 0.6.0 and cli 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.10.0] - 2024-08-28
 
 ## Changed
 
@@ -161,6 +161,8 @@
 - `sync` subcommand support to sync with latest Tinted Theming schemes
 - `build` subcommand to trigger theme template build
 
+[0.10.0]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.5...v0.10.0
+[0.9.5]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.3...v0.9.5
 [0.9.4]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 - Breaking change: Use `SchemeSystem` and `SchemeVariant` enums for
   scheme `system` and `variant` properties respectively instead of using
   string values
+- Schemes are not required to be in directories named after the scheme
+  `system`. Any `.yaml` or `.yml` scheme file will be collected into the
+  scheme system based on the `system` property defined in the scheme
+  file. Current supported systems are `base16` and `base24`
+
+## Added
+
+- Support for `0.11.1` Tinted Theming builder specification. Dotfile
+  (`.*.yaml` and `.*.yml`) will be ignored
+- Documentation for public operation functions
 
 ## Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "tinted-builder"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "tinted-builder-rust"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/tinted-builder-rust.svg)](https://crates.io/crates/tinted-builder-rust)
 [![Tests](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml)
 
-A builder for [base16] and [base24] templates using the `0.11.0` [builder
+A builder for [base16] and [base24] templates using the `0.11.1` [builder
 specification].
 
 This repo contains a command-line tool, [tinted-builder-rust], to build
@@ -75,7 +75,7 @@ The following is a table of the available subcommands for the CLI tool (tinted-b
 
 ## Builder specification
 
-tinted-builder-rust implements the `0.11.0` [builder specification]. This
+tinted-builder-rust implements the `0.11.1` [builder specification]. This
 specification details the scheme yaml format or schema as well as the
 variables the builder should provide when rendering template mustache
 file. Have a look at the [builder specification] document for more
@@ -85,7 +85,7 @@ details.
 
 This library exposes a `Scheme` and `Template` struct which you can
 use to generate your own themes using [base16] and [base24] templates and
-`0.11.0` compliant base16 and base24 scheme files.
+`0.11.1` compliant base16 and base24 scheme files.
 
 Internally tinted-builder-rust uses [ribboncurls] to render the templates.
 
@@ -139,7 +139,7 @@ The `Template` struct simply sets the content provided to it via
 `Template::new`.
 
 `template.render_to_file(&scheme)` takes the scheme and generates the
-variables defined in the `0.11.0` [builder specification].
+variables defined in the `0.11.1` [builder specification].
 
 ## Contributing
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -5,7 +5,7 @@ This page lists the licenses of the projects used in cargo-about.
 ## Overview of licenses
 
 - Apache License 2.0 (41)
-- MIT License (8)
+- MIT License (9)
 - Mozilla Public License 2.0 (1)
 - Unicode License Agreement - Data Files and Software (2016) (1)
 
@@ -1270,12 +1270,12 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 - [proc-macro2 1.0.85](https://github.com/dtolnay/proc-macro2)
 - [quote 1.0.36](https://github.com/dtolnay/quote)
 - [ryu 1.0.18](https://github.com/dtolnay/ryu)
-- [serde 1.0.203](https://github.com/serde-rs/serde)
-- [serde_derive 1.0.203](https://github.com/serde-rs/serde)
+- [serde 1.0.206](https://github.com/serde-rs/serde)
+- [serde_derive 1.0.206](https://github.com/serde-rs/serde)
 - [serde_yaml 0.9.34+deprecated](https://github.com/dtolnay/serde-yaml)
 - [syn 2.0.66](https://github.com/dtolnay/syn)
-- [thiserror-impl 1.0.61](https://github.com/dtolnay/thiserror)
-- [thiserror 1.0.61](https://github.com/dtolnay/thiserror)
+- [thiserror-impl 1.0.63](https://github.com/dtolnay/thiserror)
+- [thiserror 1.0.63](https://github.com/dtolnay/thiserror)
 - [unicode-ident 1.0.12](https://github.com/dtolnay/unicode-ident)
 - [utf8parse 0.2.2](https://github.com/alacritty/vte)
 - [vte 0.11.1](https://github.com/alacritty/vte)
@@ -1683,9 +1683,9 @@ limitations under the License.
 
 #### Used by
 
-- [tinted-builder 0.3.0](https://github.com/tinted-theming/tinted-builder-rust)
-- [tinted-builder-rust 0.6.0](https://github.com/tinted-theming/tinted-builder-rust)
-- [ribboncurls 0.2.0](https://github.com/tinted-theming/ribboncurls)
+- [tinted-builder 0.6.0](https://github.com/tinted-theming/tinted-builder-rust)
+- [tinted-builder-rust 0.10.0](https://github.com/tinted-theming/tinted-builder-rust)
+- [ribboncurls 0.2.1](https://github.com/tinted-theming/ribboncurls)
 
 ```
 Apache License
@@ -1908,6 +1908,39 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+```
+
+### MIT License
+
+#### Used by
+
+- [quick-xml 0.36.1](https://github.com/tafia/quick-xml)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2016 Johann Tuffe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Build all the schemes for a base16 or tinted repo'
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/tinted-theming/tinted-builder-rust:v0.9.5'
+  image: 'docker://ghcr.io/tinted-theming/tinted-builder-rust:v0.10.0'
   args:
     - build
     - .

--- a/tinted-builder-rust/Cargo.toml
+++ b/tinted-builder-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinted-builder-rust"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 authors = ["Jamy Golden <code@jamygolden.com>", "Tinted Theming <tintedtheming@proton.me>"]
 license = "MIT OR Apache-2.0"
@@ -24,7 +24,7 @@ strip-ansi-escapes = "0.2.0"
 
 [dependencies.tinted-builder]
 path = "../tinted-builder"
-version = "0.5.1"
+version = "0.6.0"
 
 [[bin]]
 name = "tinted-builder-rust"

--- a/tinted-builder-rust/README.md
+++ b/tinted-builder-rust/README.md
@@ -4,8 +4,8 @@
 [![Crates.io](https://img.shields.io/crates/v/tinted-builder-rust.svg)](https://crates.io/crates/tinted-builder-rust)
 [![Tests](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml)
 
-A builder for [base16] and [base24] templates using the `0.11.0` [builder
-specification].
+A builder for [base16] and [base24] templates using the `0.11.1`
+[builder specification].
 
 This crate contains a command-line tool to build base16 and base24
 templates. It is also a library crate which you can use to directly
@@ -67,7 +67,7 @@ The following is a table of the available subcommands for the CLI tool (tinted-b
 
 ## Builder specification
 
-tinted-builder-rust implements the `0.11.0` [builder specification]. This
+tinted-builder-rust implements the `0.11.1` [builder specification]. This
 specification details the scheme yaml format or schema as well as the
 variables the builder should provide when rendering template mustache
 file. Have a look at the [builder specification] document for more

--- a/tinted-builder-rust/src/operations/build.rs
+++ b/tinted-builder-rust/src/operations/build.rs
@@ -3,79 +3,51 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::{self, create_dir_all, read_to_string};
 use std::path::{Path, PathBuf};
-use tinted_builder::{Base16Scheme, Scheme, SchemeSystem, Template};
+use tinted_builder::{Scheme, SchemeSystem, Template};
 
 use crate::utils::write_to_file;
 
 const REPO_NAME: &str = env!("CARGO_PKG_NAME");
 
-// Allow for the use of `.yaml` and `.yml` extensions
-fn get_theme_template_path(theme_template_path: &Path) -> Result<PathBuf> {
-    if theme_template_path.join("templates/config.yml").is_file() {
-        return Ok(theme_template_path.join("templates/config.yml"));
-    }
-
-    Ok(theme_template_path.join("templates/config.yaml"))
-}
-
-fn generate_theme(
-    template_content: &str,
-    output_dir: &PathBuf,
-    scheme_path: &PathBuf,
-    system: SchemeSystem,
-    extension: &str,
-) -> Result<()> {
-    let scheme_file_extension: &str = scheme_path
-        .extension()
-        .unwrap_or_default()
-        .to_str()
-        .unwrap_or_default();
-
-    if scheme_file_extension == "yaml" || scheme_file_extension == "yml" {
-        let slug = scheme_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or_default();
-        let scheme_str = read_to_string(scheme_path)?;
-        let scheme: Base16Scheme = serde_yaml::from_str(&scheme_str)?;
-        let output_path = output_dir.join(format!("{}-{}.{}", &scheme.system, slug, extension));
-
-        if scheme.system != system {
-            return Ok(());
-        }
-
-        if !output_path.exists() {
-            fs::create_dir_all(output_dir)?;
-        }
-
-        let scheme = match system {
-            SchemeSystem::Base16 => Scheme::Base16(scheme.clone()),
-            SchemeSystem::Base24 => Scheme::Base24(scheme.clone()),
-            _ => {
-                // This error should be previously caught during deserialization
-                return Err(anyhow!(
-                    "Unknown `system` variant defined in `templates/config.yaml`"
-                ));
-            }
-        };
-        let template = Template::new(template_content.to_string(), scheme);
-        let output = template.render()?;
-
-        write_to_file(&output_path, &output)?;
-    }
-
-    Ok(())
-}
-
-#[derive(Debug, Deserialize)]
-struct TemplateConfig {
-    extension: String,
-    output: String,
-    #[serde(rename = "supported-systems")]
-    supported_systems: Option<Vec<SchemeSystem>>,
-}
-
-/// Build theme template using provided schemes
+/// Builds themes using the provided template and user schemes.
+///
+/// This function is typically invoked as part of a CLI operation, such as `tinted-builder-rust
+/// build`. It reads a theme template configuration file, processes user-defined color schemes, and
+/// generates the appropriate themes based on the configuration. The function assumes that the
+/// necessary scheme files have been synchronized locally. If they are not present, it prompts the
+/// user to sync them first.
+///
+/// # Arguments
+///
+/// * `theme_template_path` - A reference to a `Path` representing the path to the theme template
+/// directory or file. * `user_schemes_path` - A reference to a `Path` representing the directory
+/// where user schemes are stored. * `is_quiet` - A boolean flag that, when set to `true`,
+/// suppresses most of the output, making the build process quieter.
+///
+/// # Returns
+///
+/// Returns a `Result<()>` indicating success (`Ok(())`) or an error (`Err`) if any issues are
+/// encountered during the build process.
+///
+/// # Errors
+///
+/// This function can return an error in several scenarios:
+///
+/// * If the user schemes directory does not exist locally, it suggests running the `sync` command
+/// first. * If the theme template configuration file is missing or invalid (e.g., not a valid YAML
+/// file). * If there are issues reading the template configuration or parsing it as a YAML file. *
+/// If there are errors during the theme generation process for any configuration.
+///
+/// # Usage
+///
+/// This function is intended to be called from a CLI context, as in:
+///
+/// ```sh
+/// tinted-builder-rust build /path/to/theme-template
+/// ```
+///
+/// The function will read the configuration from the specified paths and generate the
+/// corresponding themes.
 pub fn build(theme_template_path: &Path, user_schemes_path: &Path, is_quiet: bool) -> Result<()> {
     if !user_schemes_path.exists() {
         return Err(anyhow!(
@@ -95,80 +67,374 @@ pub fn build(theme_template_path: &Path, user_schemes_path: &Path, is_quiet: boo
     let template_config_content = read_to_string(template_config_path)?;
     let template_config: HashMap<String, TemplateConfig> =
         serde_yaml::from_str(&template_config_content)?;
+    let schemes_filetypes = get_recursive_scheme_paths_from_dir(user_schemes_path)?;
 
-    for (key, value) in template_config.iter() {
-        let extension = value
-            .extension
-            .as_str()
-            .strip_prefix('.')
-            .unwrap_or(value.extension.as_str());
-        let template_path = theme_template_path.join(format!("templates/{}.mustache", key));
-        let template_content = read_to_string(&template_path).context(format!(
-            "Mustache template missing: {}",
-            template_path.display()
-        ))?;
-        let supported_systems = &value
-            .supported_systems
-            .clone()
-            .unwrap_or(vec![SchemeSystem::default()]);
-        let output_str = &value.output;
-        let output_path = if output_str.is_empty() {
-            PathBuf::from(theme_template_path)
-        } else {
-            theme_template_path.join(output_str)
-        };
+    // For each template definition in the templates/config.yaml file
+    for (config_name, config_value) in template_config.iter() {
+        generate_themes_for_config(
+            config_name,
+            config_value,
+            theme_template_path,
+            &schemes_filetypes,
+            is_quiet,
+        )?;
+    }
 
-        if output_str.starts_with('/') {
-            return Err(anyhow!(
-                "`output` value in config.yaml only accepts relative paths: {}",
-                output_str
-            ));
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+enum SchemeFileType {
+    Yaml(PathBuf),
+    Yml(PathBuf),
+}
+
+impl SchemeFileType {
+    pub fn new(path: &Path) -> Result<Self> {
+        let extension = path
+            .extension()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default();
+
+        match extension {
+            "yaml" => Ok(Self::Yaml(path.to_path_buf())),
+            "yml" => Ok(Self::Yml(path.to_path_buf())),
+            _ => Err(anyhow!("Invalid file extension: {}", extension.to_string())),
         }
+    }
 
-        if !output_path.exists() {
-            create_dir_all(&output_path)?
-        }
+    pub fn get_scheme(&self) -> Result<Scheme> {
+        match self {
+            Self::Yaml(path) | Self::Yml(path) => {
+                let scheme_str = read_to_string(path)?;
+                let scheme: serde_yaml::Value = serde_yaml::from_str(&scheme_str)?;
 
-        let mut scheme_path_vec: Vec<(SchemeSystem, PathBuf)> = Vec::new();
+                if let serde_yaml::Value::Mapping(map) = scheme {
+                    match map.get("system") {
+                        Some(serde_yaml::Value::String(system_str))
+                            if system_str == &SchemeSystem::Base24.to_string() =>
+                        {
+                            let scheme_inner =
+                                serde_yaml::from_value(serde_yaml::Value::Mapping(map))?;
+                            let scheme = Scheme::Base24(scheme_inner);
 
-        for system in supported_systems {
-            if user_schemes_path.join(system.as_str()).is_dir() {
-                let path = user_schemes_path.join(system.as_str());
+                            Ok(scheme)
+                        }
+                        None | Some(_) => {
+                            let scheme_inner =
+                                serde_yaml::from_value(serde_yaml::Value::Mapping(map))?;
+                            let scheme = Scheme::Base16(scheme_inner);
 
-                scheme_path_vec.push((system.clone(), path));
-            } else {
-                let path = user_schemes_path.to_path_buf();
-
-                scheme_path_vec.push((system.clone(), path));
-            }
-        }
-
-        for (system, schemes_path) in scheme_path_vec {
-            for item_result in fs::read_dir(schemes_path)? {
-                let scheme_direntry = item_result?;
-                let scheme_file_path = scheme_direntry.path();
-
-                generate_theme(
-                    &template_content,
-                    &output_path,
-                    &scheme_file_path,
-                    system.clone(),
-                    extension,
-                )?;
-            }
-
-            if !is_quiet {
-                println!(
-                    "{} themes generated for \"{}\" at \"{}/{}-*.{}\"",
-                    system,
-                    key,
-                    output_path.display(),
-                    system,
-                    extension,
-                );
+                            Ok(scheme)
+                        }
+                    }
+                } else {
+                    Err(anyhow!("Unable to get scheme from SchemeFileType"))
+                }
             }
         }
     }
 
+    pub fn get_path(&self) -> Option<PathBuf> {
+        match self {
+            Self::Yaml(path) | Self::Yml(path) => Some(path.to_path_buf()),
+        }
+    }
+
+    pub fn get_file_stem(&self) -> Result<String> {
+        match self {
+            Self::Yaml(path) | Self::Yml(path) => {
+                let file_stem = path
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
+
+                if file_stem.is_empty() {
+                    Err(anyhow!(
+                        "Unable to extract file_stem from path: {}",
+                        path.display()
+                    ))
+                } else {
+                    Ok(file_stem.to_string())
+                }
+            }
+        }
+    }
+}
+
+// Allow for the use of `.yaml` and `.yml` extensions
+fn get_theme_template_path(theme_template_path: &Path) -> Result<PathBuf> {
+    if theme_template_path.join("templates/config.yml").is_file() {
+        return Ok(theme_template_path.join("templates/config.yml"));
+    }
+
+    Ok(theme_template_path.join("templates/config.yaml"))
+}
+
+/// Generates a theme file based on a given template and scheme.
+///
+/// This function processes a scheme file and generates a themed output file
+/// in the specified directory. It reads the scheme data, applies it to the template,
+/// and writes the output to a file with the appropriate extension.
+///
+/// The function also filters out hidden files (those whose names start with a `.`)
+/// and ensures that the scheme system matches the provided `SchemeSystem`.
+///
+/// # Arguments
+///
+/// * `template_content` - A reference to a string slice containing the template's content.
+/// * `output_dir` - A reference to a `PathBuf` representing the directory where the output file will be written.
+/// * `scheme_path` - A reference to a `Path` representing the file path to the scheme file.
+/// * `system` - The `SchemeSystem` that the scheme file should match.
+/// * `extension` - A string slice representing the file extension for the generated theme file.
+///
+/// # Returns
+///
+/// Returns `Result<()>` indicating success (`Ok(())`) or an error (`Err`) if any of the following conditions are met:
+///
+/// * The scheme file cannot be read or parsed.
+/// * The output directory cannot be created.
+/// * There is an issue with writing the output file.
+/// * The scheme file's system does not match the provided `SchemeSystem`.
+///
+/// # Errors
+///
+/// This function can return an error in several scenarios:
+///
+/// * If the scheme file cannot be read from the specified path.
+/// * If the scheme file content cannot be parsed into a `Base16Scheme`.
+/// * If the output directory cannot be created.
+/// * If the template cannot be rendered with the provided scheme.
+/// * If there is an issue writing the generated output to the file.
+/// * If the scheme file's system does not match the provided `SchemeSystem`.
+///
+/// Note: This function skips processing hidden files (files whose names start with a `.`).
+fn generate_theme(
+    template_content: &str,
+    output_dir: &PathBuf,
+    scheme_path: &Path,
+    system: SchemeSystem,
+    extension: &str,
+) -> Result<()> {
+    let scheme_file_type = SchemeFileType::new(scheme_path)?;
+    let scheme_path = scheme_file_type
+        .get_path()
+        .ok_or(anyhow!("Unable to get path from FileType"))?;
+    let scheme_file_stem = scheme_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default();
+
+    // Ignore hidden files
+    if scheme_file_stem.starts_with('.') {
+        return Ok(());
+    }
+
+    let scheme = scheme_file_type.get_scheme()?;
+
+    match &scheme {
+        Scheme::Base16(scheme_inner) | Scheme::Base24(scheme_inner) => {
+            if scheme_inner.system != system {
+                return Err(anyhow!(
+                    "Scheme enum variant is mismatched with the provided scheme (\"{}\")",
+                    system
+                ));
+            }
+
+            let template = Template::new(template_content.to_string(), scheme.clone());
+            let output = template.render()?;
+            let output_path = output_dir.join(format!(
+                "{}-{}.{}",
+                &scheme_inner.system,
+                scheme_file_type.get_file_stem().unwrap_or_default(),
+                extension
+            ));
+
+            if !output_path.exists() {
+                fs::create_dir_all(output_dir)?;
+            }
+
+            write_to_file(&output_path, &output)?;
+        }
+        _ => {
+            return Err(anyhow!("Unknown Scheme enum variant"));
+        }
+    }
+
     Ok(())
+}
+
+fn generate_themes_for_config(
+    config_name: &str,
+    config_value: &TemplateConfig,
+    theme_template_path: &Path,
+    schemes_filetypes: &[SchemeFileType],
+    is_quiet: bool,
+) -> Result<()> {
+    let extension = config_value
+        .extension
+        .as_str()
+        .strip_prefix('.')
+        .unwrap_or(config_value.extension.as_str());
+    let template_path = theme_template_path.join(format!("templates/{}.mustache", config_name));
+    let template_content = read_to_string(&template_path).context(format!(
+        "Mustache template missing: {}",
+        template_path.display()
+    ))?;
+    let supported_systems = &config_value
+        .supported_systems
+        .clone()
+        .unwrap_or(vec![SchemeSystem::default()]);
+    let output_str = &config_value.output;
+    let output_path = if output_str.is_empty() {
+        PathBuf::from(theme_template_path)
+    } else {
+        theme_template_path.join(output_str)
+    };
+
+    if output_str.starts_with('/') {
+        return Err(anyhow!(
+            "`output` value in config.yaml only accepts relative paths: {}",
+            output_str
+        ));
+    }
+
+    if !output_path.exists() {
+        create_dir_all(&output_path)?
+    }
+
+    let schemes_result_vec: Vec<(PathBuf, Result<Scheme>)> = schemes_filetypes
+        .iter()
+        .map(|item| (item.get_path().unwrap_or_default(), item.get_scheme()))
+        .collect();
+    let scheme_err_path_option = schemes_result_vec.iter().find_map(|(path, scheme)| {
+        if let Err(err_message) = scheme {
+            Some((path, err_message))
+        } else {
+            None
+        }
+    });
+
+    if let Some((path, err_message)) = scheme_err_path_option {
+        return Err(anyhow!(
+            "Unable to deserialize scheme \"{}\": {}",
+            path.display(),
+            err_message
+        ));
+    }
+
+    let schemes_vec = schemes_result_vec
+        .into_iter()
+        .filter_map(|(path, scheme_result)| match &scheme_result {
+            Ok(Scheme::Base16(scheme)) | Ok(Scheme::Base24(scheme)) => {
+                if supported_systems.contains(&scheme.system) {
+                    // This should always unwrap since `Err` variant checking happens in the step
+                    // before this
+                    Some((path, scheme_result.unwrap()))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        });
+
+    for (scheme_path, scheme) in schemes_vec {
+        let scheme_system = scheme.get_scheme_system();
+
+        generate_theme(
+            &template_content,
+            &output_path,
+            &scheme_path,
+            scheme_system,
+            extension,
+        )?;
+    }
+
+    if !is_quiet {
+        println!(
+            "Successfully generated \"{}\" themes for \"{}\" at \"{}/*.{}\"",
+            supported_systems
+                .iter()
+                .map(|item| item.as_str().to_string())
+                .collect::<Vec<String>>()
+                .join(", "),
+            config_name,
+            output_path.display(),
+            extension,
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct TemplateConfig {
+    extension: String,
+    output: String,
+    #[serde(rename = "supported-systems")]
+    supported_systems: Option<Vec<SchemeSystem>>,
+}
+
+/// Recursively retrieves scheme file paths from a directory.
+///
+/// This function traverses the given directory recursively, gathering all valid scheme files.
+/// It skips hidden files and directories (those whose names start with a `.`).
+///
+/// # Arguments
+///
+/// * `dirpath` - A reference to a `Path` representing the directory to start the search from.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a `Vec<SchemeFileType>` if successful, where `SchemeFileType`
+/// represents a valid scheme file. If any error occurs during directory traversal or file handling,
+/// an `Err` with the relevant error information is returned.
+///
+/// # Errors
+///
+/// This function can return an error in the following scenarios:
+///
+/// * If the directory cannot be read.
+/// * If there is an issue accessing the contents of the directory.
+/// * If there is an issue creating a `SchemeFileType` from a file path.
+fn get_recursive_scheme_paths_from_dir(dirpath: &Path) -> Result<Vec<SchemeFileType>> {
+    let mut scheme_paths: Vec<SchemeFileType> = vec![];
+
+    for item in dirpath.read_dir()? {
+        let file_path = item?.path();
+        let file_stem = file_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default();
+
+        // Skip hidden files and directories
+        if file_stem.starts_with('.') {
+            continue;
+        }
+
+        if file_path.is_dir() {
+            let inner_scheme_paths_result = get_recursive_scheme_paths_from_dir(&file_path);
+
+            if let Ok(inner_scheme_paths) = inner_scheme_paths_result {
+                scheme_paths.extend(inner_scheme_paths);
+            }
+
+            continue;
+        }
+
+        let scheme_file_type_result = SchemeFileType::new(&file_path);
+
+        match scheme_file_type_result {
+            Ok(scheme_file_type) => {
+                scheme_paths.push(scheme_file_type);
+            }
+            Err(_) => continue,
+        }
+    }
+
+    Ok(scheme_paths)
 }

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 - 2024-08-28
 
 ## Added
 

--- a/tinted-builder/Cargo.toml
+++ b/tinted-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tinted-builder"
 description = "A Tinted Theming template builder which uses yaml color schemes to generate theme files."
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/tinted-builder/README.md
+++ b/tinted-builder/README.md
@@ -4,12 +4,12 @@
 [![Crates.io](https://img.shields.io/crates/v/tinted-builder-rust.svg)](https://crates.io/crates/tinted-builder-rust)
 [![Tests](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/tinted-theming/tinted-builder-rust/actions/workflows/ci.yml)
 
-A Rust library to generate [base16] and [base24] templates using the `0.11.0` [builder
-specification].
+A Rust library to generate [base16] and [base24] templates using the
+`0.11.1` [builder specification].
 
-This library exposes a `Scheme` and `Template` struct which you can
-use to generate your own themes using [base16] and [base24] templates and
-`0.11.0` compliant base16 and base24 scheme files.
+This library exposes a `Scheme` and `Template` struct which you can use
+to generate your own themes using [base16] and [base24] templates and
+`0.11.1` compliant base16 and base24 scheme files.
 
 Internally tinted-builder uses [ribboncurls] to render the templates.
 
@@ -67,7 +67,7 @@ let output = template
    `Scheme` variant in step 1 into the `Template` struct:
    `Template::new(mustache_text, scheme)`. The `template.render()`
    method takes the scheme, generates the variables defined in the 
-   `0.11.0` [builder specification] and returns a new string.
+   `0.11.1` [builder specification] and returns a new string.
 3. Render the template by running a method which returns a
    `Result<String, TintedBuilderError>` type: 
    `let output = template.render().unwrap();`

--- a/tinted-builder/src/error.rs
+++ b/tinted-builder/src/error.rs
@@ -50,4 +50,10 @@ pub enum TintedBuilderError {
     /// such as "dark" or "light".
     #[error("invalid scheme variant: {0}")]
     InvalidSchemeVariant(String),
+
+    /// Error indicating that an invalid scheme system was provided.
+    ///
+    /// This variant is used when an input string does not correspond to any valid scheme system
+    #[error("invalid scheme system: {0}")]
+    InvalidSchemeSystem(String),
 }

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -12,12 +12,22 @@ use crate::TintedBuilderError;
 /// additional variants may be added in future versions without it being considered a breaking
 /// change.
 #[non_exhaustive]
+#[derive(Debug, Clone)]
 pub enum Scheme {
     /// Base16 variant with Base16Scheme deserialized content.
     Base16(Base16Scheme),
     /// Base24 variant with Base16Scheme deserialized content. Base16Scheme is built to support
     /// basic supersets of Base16 schemes.
     Base24(Base16Scheme),
+}
+
+impl Scheme {
+    pub fn get_scheme_system(&self) -> SchemeSystem {
+        match self {
+            Scheme::Base16(_) => SchemeSystem::Base16,
+            Scheme::Base24(_) => SchemeSystem::Base24,
+        }
+    }
 }
 
 /// Enum representing the scheme system. This enum is non-exhaustive, meaning additional variants
@@ -48,6 +58,26 @@ impl fmt::Display for SchemeSystem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())?;
         Ok(())
+    }
+}
+
+impl FromStr for SchemeSystem {
+    type Err = TintedBuilderError;
+
+    /// Parses a string to create a `SchemeSystem`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TintedBuilderError` if the input string does not match
+    /// any valid scheme variant.
+    fn from_str(system_str: &str) -> Result<Self, Self::Err> {
+        match system_str {
+            "base16" => Ok(Self::Base16),
+            "base24" => Ok(Self::Base24),
+            _ => Err(TintedBuilderError::InvalidSchemeSystem(
+                system_str.to_string(),
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Adds support for builder spec `0.11.1` and changes library API to cater for different system variants in builder.

## Lib

```yaml
## 0.6.0 - 2024-08-28

## Added

- Add basic documentation for docs.rs

## Changed

- Require schemes to be wrapped in `Scheme` enum when creating a
  `Template` struct instance to easily extend builder to support
  different scheme systems
- Use `SchemeSystem` and `SchemeVariant` enums for scheme `system` and
  `variant` properties respectively instead of using string values

## Removed

- `anyhow` crate moved to dev-dependency for tests, but replaced with
  `TintedBuilderError` enum with `thiserror` macros in API
```

## Cli

```yaml
## [0.10.0] - 2024-08-28

## Changed

- Breaking change: `tinted-builder` library includes an API change and
  `tinted-builder-rust` now exports the new `tinted-builder` API
- Breaking change: Use `SchemeSystem` and `SchemeVariant` enums for
  scheme `system` and `variant` properties respectively instead of using
  string values
- Schemes are not required to be in directories named after the scheme
  `system`. Any `.yaml` or `.yml` scheme file will be collected into the
  scheme system based on the `system` property defined in the scheme 
  file. Current supported systems are `base16` and `base24`

## Added

- Support for `0.11.1` Tinted Theming builder specification. Dotfile
  (`.*.yaml` and `.*.yml`) will be ignored
- Documentation for public operation functions

## Removed

- Remove deprecated `render_to_file` `Template` method
```
