### PR TITLE
Add 16bit rgb context values for mustache templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.0] - 2024-09-07
+
+## Added
+
+- Add support for proposed 0.12.0 builder spec by adding 16bit rgb
+  colour variables to the mustache context
+
 ## [0.10.1] - 2024-09-03
 
 ## Fixed
@@ -169,6 +176,7 @@
 - `sync` subcommand support to sync with latest Tinted Theming schemes
 - `build` subcommand to trigger theme template build
 
+[0.11.0]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/tinted-theming/tinted-builder-rust/compare/v0.9.3...v0.9.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "tinted-builder"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "tinted-builder-rust"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1683,8 +1683,8 @@ limitations under the License.
 
 #### Used by
 
-- [tinted-builder 0.6.0](https://github.com/tinted-theming/tinted-builder-rust)
-- [tinted-builder-rust 0.10.1](https://github.com/tinted-theming/tinted-builder-rust)
+- [tinted-builder 0.7.0](https://github.com/tinted-theming/tinted-builder-rust)
+- [tinted-builder-rust 0.11.0](https://github.com/tinted-theming/tinted-builder-rust)
 - [ribboncurls 0.2.1](https://github.com/tinted-theming/ribboncurls)
 
 ```

--- a/tinted-builder-rust/Cargo.toml
+++ b/tinted-builder-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinted-builder-rust"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["Jamy Golden <code@jamygolden.com>", "Tinted Theming <tintedtheming@proton.me>"]
 license = "MIT OR Apache-2.0"
@@ -24,7 +24,7 @@ strip-ansi-escapes = "0.2.0"
 
 [dependencies.tinted-builder]
 path = "../tinted-builder"
-version = "0.6.0"
+version = "0.7.0"
 
 [[bin]]
 name = "tinted-builder-rust"

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.0 - 2024-09-07
+
+## Added
+
+- Add support for proposed 0.12.0 builder spec by adding 16bit rgb
+  colour variables to the mustache context
+
 ## 0.6.0 - 2024-08-28
 
 ## Added

--- a/tinted-builder/Cargo.toml
+++ b/tinted-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tinted-builder"
 description = "A Tinted Theming template builder which uses yaml color schemes to generate theme files."
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/tinted-builder/src/template/base16.rs
+++ b/tinted-builder/src/template/base16.rs
@@ -55,6 +55,18 @@ pub(crate) fn to_template_context(scheme: &Base16Scheme) -> HashMap<String, Stri
         context.insert(format!("{}-rgb-g", name), rgb.1.to_string());
         context.insert(format!("{}-rgb-b", name), rgb.2.to_string());
         context.insert(
+            format!("{}-rgb16-r", name),
+            (rgb.0 as u16 * 257_u16).to_string(),
+        );
+        context.insert(
+            format!("{}-rgb16-g", name),
+            (rgb.1 as u16 * 257_u16).to_string(),
+        );
+        context.insert(
+            format!("{}-rgb16-b", name),
+            (rgb.2 as u16 * 257_u16).to_string(),
+        );
+        context.insert(
             format!("{}-dec-r", name),
             format!("{:.8}", rgb.0 as f64 / 255.),
         );

--- a/tinted-builder/tests/general.rs
+++ b/tinted-builder/tests/general.rs
@@ -140,6 +140,18 @@ fn render_rgb() -> Result<()> {
 }
 
 #[test]
+fn render_rgb16() -> Result<()> {
+    let template_source = "{{base0A-rgb16-r}} {{base0A-rgb16-g}} {{base0A-rgb16-b}}";
+    let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);
+    let template = Template::new(template_source.to_string(), scheme);
+
+    let output = template.render()?;
+
+    assert_eq!(output, "53199 44461 9509");
+    Ok(())
+}
+
+#[test]
 fn render_dec() -> Result<()> {
     let template_source = "{{base0A-dec-r}} {{base0A-dec-g}} {{base0A-dec-b}}";
     let scheme = Scheme::Base16(serde_yaml::from_str(SCHEME_SILK_LIGHT)?);


### PR DESCRIPTION
Add support for proposed builder spec `0.12.0`: https://github.com/tinted-theming/home/pull/111

While it's not final yet, I need this functionality in the builder to create oascripts to change the iterm2 theme: https://github.com/tinted-theming/tinted-iterm2/pull/13