### PR TITLE
Add list scheme system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Add support for `list`, `listbase16` and `listbase24` scheme systems
+  for use in the `templates/config.yaml` file to add a `schemes` list to
+  mustache context to be able to list scheme information in a single
+  file.
+
 ### Changed
 
 - Change `get_scheme_files` and `SchemeFile::new` type arguments from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ribboncurls"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0159faf91aa68fbc9798280fdda9f704871561156ffd0f1f49cee80b6000c828"
+checksum = "6fb3028bdec0e690dd492c976f33a482fcb8d910291b2d99ee6d2680c6540121"
 dependencies = [
  "html-escape",
  "regex",
@@ -405,6 +405,7 @@ dependencies = [
  "clap",
  "dirs",
  "regex",
+ "ribboncurls",
  "serde",
  "serde_yaml",
  "strip-ansi-escapes",

--- a/tinted-builder-rust/Cargo.toml
+++ b/tinted-builder-rust/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.80"
 clap = "4.5.2"
 dirs = "5.0.1"
 regex = "1.11.0"
+ribboncurls = "0.4.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.32"
 

--- a/tinted-builder-rust/README.md
+++ b/tinted-builder-rust/README.md
@@ -65,6 +65,40 @@ The following is a table of the available subcommands for the CLI tool (tinted-b
 | `--help` `-h`     | Displays help information for the subcommand. | All | - | `tinted-builder-rust --help`, `tinted-builder-rust build --help`, etc |
 | `--version` `-V`  | Shows the version of tinted-builder-rust. | All | - | `tinted-builder-rust --version` |
 
+## List usage
+
+`tinted-builder-rust` supports `list`, `listbase16` and `listbase24`
+scheme systems. This allows for listing scheme information in a single
+file, eg:
+
+`template-repo/templates/config.yaml`:
+
+```yaml
+some-base16-list:
+    filename: "base16-list.md"
+    supported-systems: [listbase16]
+
+some-base24-list:
+    filename: "base24-list.md"
+    supported-systems: [listbase24]
+
+list-all:
+    filename: "list-all.md"
+    supported-systems: [list]
+```
+
+With an example template being `templates/some-base16-list.mustache`:
+
+```
+{{#schemes}}
+  {{system}}-{{slug}} (variant: {{variant}}
+{{/schemes}
+```
+
+Note: These are unofficial scheme-systems, meaning it's not
+part of the Tinted Theming scheme specification.
+
+
 ## Builder specification
 
 tinted-builder-rust implements the `0.11.1` [builder specification]. This

--- a/tinted-builder-rust/tests/fixtures/rendered/list.md
+++ b/tinted-builder-rust/tests/fixtures/rendered/list.md
@@ -1,0 +1,1 @@
+base16-silk-light - variant: light

--- a/tinted-builder-rust/tests/fixtures/rendered/listbase16.md
+++ b/tinted-builder-rust/tests/fixtures/rendered/listbase16.md
@@ -1,2 +1,1 @@
 base16-silk-light - variant: light
-base24-dracula - variant: dark

--- a/tinted-builder-rust/tests/fixtures/rendered/listbase24.md
+++ b/tinted-builder-rust/tests/fixtures/rendered/listbase24.md
@@ -1,0 +1,1 @@
+base24-dracula - variant: dark

--- a/tinted-builder-rust/tests/fixtures/templates/list-config.yaml
+++ b/tinted-builder-rust/tests/fixtures/templates/list-config.yaml
@@ -1,0 +1,3 @@
+list: 
+  filename: list.md
+  supported-systems: [list, base16]

--- a/tinted-builder-rust/tests/fixtures/templates/list-config.yaml
+++ b/tinted-builder-rust/tests/fixtures/templates/list-config.yaml
@@ -1,3 +1,3 @@
-list: 
-  filename: list.md
-  supported-systems: [list, base16]
+list:
+  filename: "{{ scheme-system }}-list.md"
+  supported-systems: [list, listbase16, listbase24]

--- a/tinted-builder-rust/tests/fixtures/templates/list-template.mustache
+++ b/tinted-builder-rust/tests/fixtures/templates/list-template.mustache
@@ -1,0 +1,3 @@
+{{#schemes}}
+{{system}}-{{slug}} - variant: {{variant}}
+{{/schemes}}

--- a/tinted-builder-rust/tests/operation_build.rs
+++ b/tinted-builder-rust/tests/operation_build.rs
@@ -414,7 +414,7 @@ fn test_operation_build_mixed() -> Result<()> {
 }
 
 #[test]
-fn test_operation_build_list() -> Result<()> {
+fn test_operation_build_listbase16() -> Result<()> {
     // -------
     // Arrange
     // -------
@@ -422,7 +422,9 @@ fn test_operation_build_list() -> Result<()> {
     let template_theme_path = PathBuf::from(format!("./template-{}", name));
     let template_templates_path = template_theme_path.join("templates");
     let schemes_path = template_theme_path.join("schemes");
-    let rendered_theme_path = template_theme_path.join("list.md");
+    let rendered_list_theme_path = template_theme_path.join("list-list.md");
+    let rendered_listbase16_theme_path = template_theme_path.join("listbase16-list.md");
+    let rendered_listbase24_theme_path = template_theme_path.join("listbase24-list.md");
 
     if template_theme_path.is_dir() {
         fs::remove_dir_all(&template_theme_path)?;
@@ -447,24 +449,34 @@ fn test_operation_build_list() -> Result<()> {
         format!("--schemes-dir={}", schemes_path.display()),
     ])
     .unwrap();
-    let rendered_content = fs::read_to_string(rendered_theme_path)?;
-    let expected_content = fs::read_to_string("./tests/fixtures/rendered/list.md")?;
+    let rendered_list_content = fs::read_to_string(rendered_list_theme_path)?;
+    let rendered_listbase16_content = fs::read_to_string(rendered_listbase16_theme_path)?;
+    let rendered_listbase24_content = fs::read_to_string(rendered_listbase24_theme_path)?;
+    let expected_list_content = fs::read_to_string("./tests/fixtures/rendered/list.md")?;
+    let expected_listbase16_content =
+        fs::read_to_string("./tests/fixtures/rendered/listbase16.md")?;
+    let expected_listbase24_content =
+        fs::read_to_string("./tests/fixtures/rendered/listbase24.md")?;
 
     // ------
     // Assert
     // ------
-    assert_eq!(rendered_content, expected_content);
+    assert_eq!(rendered_list_content, expected_list_content);
+    assert_eq!(rendered_listbase16_content, expected_listbase16_content);
+    assert_eq!(rendered_listbase24_content, expected_listbase24_content);
     assert!(
         stderr.is_empty(),
         "stderr does not contain the expected output"
     );
-    assert_eq!(
-        stdout,
-        format!(
-            "Successfully generated \"base16\" list with filename \"{}\"\n",
-            template_theme_path.join("list.md").display()
-        )
+    let expected_output = format!(
+        r#"Successfully generated "list" list with filename "{0}/{{{{ scheme-system }}}}-list.md"
+Successfully generated "listbase16" list with filename "{0}/{{{{ scheme-system }}}}-list.md"
+Successfully generated "listbase24" list with filename "{0}/{{{{ scheme-system }}}}-list.md"
+"#,
+        template_theme_path.display(),
     );
+
+    assert_eq!(stdout, expected_output);
 
     Ok(())
 }

--- a/tinted-builder-rust/tests/test_utils.rs
+++ b/tinted-builder-rust/tests/test_utils.rs
@@ -1,10 +1,6 @@
+use std::fs::{self, remove_file, File};
 use std::io::Write;
-use std::{
-    error::Error,
-    fs::{remove_file, File},
-    path::Path,
-    process::Command,
-};
+use std::{error::Error, path::Path, process::Command};
 
 use anyhow::{Context, Result};
 
@@ -42,5 +38,23 @@ pub fn write_to_file(path: impl AsRef<Path>, contents: &str) -> Result<()> {
 
     file.write_all(contents.as_bytes())?;
 
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+    fs::create_dir_all(&dst)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dest_path = dst.as_ref().join(entry.file_name());
+
+        if file_type.is_dir() {
+            copy_dir_all(entry.path(), &dest_path)?;
+        } else {
+            fs::copy(entry.path(), &dest_path)?;
+        }
+    }
     Ok(())
 }

--- a/tinted-builder-rust/tests/utils.rs
+++ b/tinted-builder-rust/tests/utils.rs
@@ -2,8 +2,8 @@ mod test_utils;
 
 use anyhow::Result;
 use std::fs;
-use std::path::{Path, PathBuf};
-use test_utils::write_to_file;
+use std::path::PathBuf;
+use test_utils::{copy_dir_all, write_to_file};
 use tinted_builder::{SchemeSystem, SchemeVariant};
 use tinted_builder_rust::utils::get_scheme_files;
 
@@ -157,22 +157,5 @@ palette:
     assert_eq!(scheme_container.get_scheme_variant(), scheme_variant);
     assert_eq!(scheme_container.get_scheme_slug(), scheme_slug);
 
-    Ok(())
-}
-
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
-    fs::create_dir_all(&dst)?;
-
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let dest_path = dst.as_ref().join(entry.file_name());
-
-        if file_type.is_dir() {
-            copy_dir_all(entry.path(), &dest_path)?;
-        } else {
-            fs::copy(entry.path(), &dest_path)?;
-        }
-    }
     Ok(())
 }

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- Add `Scheme` struct support for `list`, `listbase16` and `listbase24`
+  scheme systems
+
 ### Changed
 
 - `Base16Scheme` palette hex values are now prepended with a hash `#` to
   allow text editors to optionally highlight the color. This is optional
   under the `0.11.2` builder specification
+- Update Ribboncurls crate
 
 ## 0.8.0 - 2024-10-05
 

--- a/tinted-builder/Cargo.toml
+++ b/tinted-builder/Cargo.toml
@@ -17,7 +17,7 @@ clap = "4.5.2"
 dirs = "5.0.1"
 quick-xml = { version = "0.36.1", features = ["serialize"] }
 regex = "1.10.4"
-ribboncurls = "0.2.1"
+ribboncurls = "0.4.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.32"
 thiserror = "1.0.63"

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -80,6 +80,8 @@ pub enum SchemeSystem {
     /// Base24 scheme system.
     Base24,
     List,
+    ListBase16,
+    ListBase24,
 }
 
 impl SchemeSystem {
@@ -89,6 +91,8 @@ impl SchemeSystem {
             SchemeSystem::Base16 => "base16",
             SchemeSystem::Base24 => "base24",
             SchemeSystem::List => "list",
+            SchemeSystem::ListBase16 => "listbase16",
+            SchemeSystem::ListBase24 => "listbase24",
         }
     }
     pub fn variants() -> &'static [SchemeSystem] {

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -79,6 +79,7 @@ pub enum SchemeSystem {
     Base16,
     /// Base24 scheme system.
     Base24,
+    List,
 }
 
 impl SchemeSystem {
@@ -87,6 +88,7 @@ impl SchemeSystem {
         match self {
             SchemeSystem::Base16 => "base16",
             SchemeSystem::Base24 => "base24",
+            SchemeSystem::List => "list",
         }
     }
     pub fn variants() -> &'static [SchemeSystem] {

--- a/tinted-builder/src/scheme/base16.rs
+++ b/tinted-builder/src/scheme/base16.rs
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for Base16Scheme {
                     )));
                 }
             }
-            _ => {
+            SchemeSystem::List | SchemeSystem::ListBase16 | SchemeSystem::ListBase24 => {
                 return Err(serde::de::Error::custom(format!(
                     "{} is not a valid Scheme system for a specific scheme",
                     wrapper.system

--- a/tinted-builder/src/scheme/base16.rs
+++ b/tinted-builder/src/scheme/base16.rs
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for Base16Scheme {
                     )));
                 }
             }
-            SchemeSystem::List => {
+            _ => {
                 return Err(serde::de::Error::custom(format!(
                     "{} is not a valid Scheme system for a specific scheme",
                     wrapper.system

--- a/tinted-builder/src/scheme/base16.rs
+++ b/tinted-builder/src/scheme/base16.rs
@@ -102,6 +102,12 @@ impl<'de> Deserialize<'de> for Base16Scheme {
                     )));
                 }
             }
+            SchemeSystem::List => {
+                return Err(serde::de::Error::custom(format!(
+                    "{} is not a valid Scheme system for a specific scheme",
+                    wrapper.system
+                )));
+            }
         }
 
         let palette_result: Result<HashMap<String, Color>, _> = wrapper


### PR DESCRIPTION
Related to https://github.com/tinted-theming/tinted-builder-rust/issues/12

@RobLoach can you have a look at this locally and let me know what you think? I'll rename `list` to `index` as you suggested in the issue. Still a few more things I need to adjust before merging so creating this as a draft PR.

This can work with `someproject/templates/config.yaml`:

```yaml
list:
    filename: list.md
    supported-systems: [list, base16]
```

and: `someproject/templates/list.mustache`:

```
{{#schemes}} 
{{system}} - {{name}}
{{/schemes}}
```

and just `build` the template normally with `cargo run build /path/to/someproject`.

`supported-systems: [list, base16]` contains `base16` since I thought someone may not want to list base24 or other scheme systems.