### PR TITLE
Updated to tinted8 0.2.0 beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ your own Rust application.
 - [Library](#library)
   - [Library installation](#library-installation)
   - [Library usage](#library-usage)
+- [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -234,6 +235,18 @@ The `Template` struct simply sets the content provided to it via
 `template.render_to_file(&scheme)` takes the scheme and generates the
 variables defined in the `0.11.1` [builder specification].
 
+## Development
+
+A [justfile] is provided for common development tasks. Run `just` to
+list available recipes.
+
+| Recipe | Description | Example |
+|--------|-------------|---------|
+| `test` | Run tests for all crates, or a specific crate | `just test`, `just test tinted-builder` |
+| `fmt` | Format Rust and Nix files | `just fmt` |
+| `lint` | Run clippy | `just lint` |
+| `clean` | Remove build artifacts | `just clean` |
+
 ## Contributing
 
 Contributions are welcome! Have a look at [CONTRIBUTING.md] for more
@@ -256,5 +269,6 @@ tinted-builder-rust falls under the [GPL-3.0] license. Have a look at the
 [ribboncurls]: https://github.com/tinted-theming/ribboncurls
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [repository releases]: https://github.com/tinted-theming/tinted-builder-rust/releases/latest
+[justfile]: https://just.systems/
 [GPL-3.0]: https://github.com/IQAndreas/markdown-licenses/blob/master/gnu-gpl-v3.0.md
 [LICENSE]: ./LICENSE

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+default:
+    @just --list
+
+test project="" *args:
+    {{ if project == "" { "cargo test --workspace" } else { "cargo test -p " + project } }} {{args}}
+
+fmt:
+    cargo fmt
+    alejandra .
+
+lint:
+    cargo clippy
+
+clean:
+    rm -rf target/

--- a/tinted-builder-rust/tests/fixtures/templates/list-tinted8-template.mustache
+++ b/tinted-builder-rust/tests/fixtures/templates/list-tinted8-template.mustache
@@ -1,3 +1,3 @@
 {{#schemes}}
-{{scheme.system}}-{{scheme.slug}} - blue: #{{palette.blue.normal.hex}} - variant: {{scheme.variant}}
+{{scheme.system}}-{{scheme.slug}} - blue: #{{palette.blue.normal.hex}} - variant: {{variant}}
 {{/schemes}}

--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -20,11 +20,14 @@
   properties.
 - Expand Tinted8 UI properties, including `ui.markup.text`, plus additional UI
   key coverage.
+- Add tinted8 0.2.0-beta3 feature where the default colour values of grayscale
+  colors are different based on whether a dark or light scheme variant is active
+- Add `ui.cursor_muted`
 
 ### Changed
 
-- **BREAKING**: Tinted8 scheme `family`, `style`, and `variant` now live under
-  the `meta` object, aligning with spec 0.2.0.
+- **BREAKING**: Tinted8 scheme `family`, `style` now live under the `meta`
+  object, aligning with spec 0.2.0.
 - **BREAKING**: Library: Color API updated — `Color::new` now takes `(hex,
   Option<ColorName>, Option<ColorVariant>)`; `Color` struct gained `name` and
   `variant` fields. Pass `None` for backward-compatible behavior. Also enhances
@@ -41,6 +44,7 @@
 - Rename Tinted8 UI keys from `highlight.search-background` and
   `highlight.search-foreground` to `highlight.search.background` and
   `highlight.search.foreground`.
+- Change `ui.cursor` to `ui.cursor_normal`
 
 ### Fixed
 
@@ -48,6 +52,8 @@
 - Fix bug where `ui.whitespace.foreground` is disallowed in scheme
 - Improve error detail when deriving colors for Tinted8 palettes.
 - Fix `attribute_name` syntax key mapping to `attribute-name`.
+- Fix bug where tinted8 scheme.name isn't correctly titlecasified
+- Fix bug where `FromStr` is not implemented for `tinted8`
 
 ## 0.10.1 - 2026-01-30
 

--- a/tinted-builder/build.rs
+++ b/tinted-builder/build.rs
@@ -319,9 +319,24 @@ fn generate_valid_syntax_keys(code: &mut String, nodes: &[FlattenedNode]) {
 /// # Returns
 /// - `()` after appending to `code`.
 fn generate_get_palette_color(code: &mut String) {
-    code.push_str("fn get_palette_color(palette: &Palette, color_type: &ColorType) -> Result<Color, TintedBuilderError> {\n");
+    code.push_str("fn get_palette_color(palette: &Palette, color_type: &ColorType, variant: &SchemeVariant) -> Result<Color, TintedBuilderError> {\n");
+    code.push_str(
+        "    // For light variant, swap white↔black to handle foreground/background inversion\n",
+    );
+    code.push_str("    let color_type = match variant {\n");
+    code.push_str("        SchemeVariant::Light => match &color_type.0 {\n");
+    code.push_str(
+        "            ColorName::White => ColorType(ColorName::Black, color_type.1.clone()),\n",
+    );
+    code.push_str(
+        "            ColorName::Black => ColorType(ColorName::White, color_type.1.clone()),\n",
+    );
+    code.push_str("            _ => ColorType(color_type.0.clone(), color_type.1.clone()),\n");
+    code.push_str("        },\n");
+    code.push_str("        _ => ColorType(color_type.0.clone(), color_type.1.clone()),\n");
+    code.push_str("    };\n");
     code.push_str("    #[allow(clippy::match_same_arms)]\n");
-    code.push_str("    match color_type {\n");
+    code.push_str("    match &color_type {\n");
 
     let colors = [
         "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "orange", "gray",
@@ -331,28 +346,8 @@ fn generate_get_palette_color(code: &mut String) {
 
     for color in &colors {
         for variant in &variants {
-            let color_name: String = color
-                .chars()
-                .enumerate()
-                .map(|(index, char)| {
-                    if index == 0 {
-                        char.to_uppercase().collect::<String>()
-                    } else {
-                        char.to_string()
-                    }
-                })
-                .collect();
-            let variant_name: String = variant
-                .chars()
-                .enumerate()
-                .map(|(index, char)| {
-                    if index == 0 {
-                        char.to_uppercase().collect::<String>()
-                    } else {
-                        char.to_string()
-                    }
-                })
-                .collect();
+            let color_name = capitalize(color);
+            let variant_name = capitalize(variant);
             let _ = writeln!(
                 code,
                 r"        ColorType(ColorName::{color_name}, ColorVariant::{variant_name}) => Color::new(&palette.{color}_{variant}.to_hex(), Some(ColorName::{color_name}), Some(ColorVariant::{variant_name})),"
@@ -375,7 +370,7 @@ fn generate_get_palette_color(code: &mut String) {
 fn generate_try_from_basic(code: &mut String, nodes: &[SyntaxNode]) {
     code.push_str("#[allow(clippy::too_many_lines)]\n");
     code.push_str(
-        "pub fn generated_try_from_basic(basic: &BasicSyntax, palette: &Palette) -> Result<Syntax, SyntaxError> {\n",
+        "pub fn generated_try_from_basic(basic: &BasicSyntax, palette: &Palette, variant: &SchemeVariant) -> Result<Syntax, TintedBuilderError> {\n",
     );
 
     generate_syntax_construction(code, nodes, "    ", None);
@@ -419,7 +414,7 @@ fn generate_syntax_construction(
         if node.children.is_empty() {
             let _ = writeln!(
                 code,
-                "{indent}let {variant_name} = parse_or_inherit(&[{}], &get_palette_color(palette, &ColorType::from_str(\"{default_color}\")?)?)?;",
+                "{indent}let {variant_name} = parse_or_inherit(&[{}], &get_palette_color(palette, &ColorType::from_str(\"{default_color}\")?, variant)?)?;",
                 format_parent_chain(&basic_field, &parent_chain)
             );
         } else {
@@ -429,7 +424,7 @@ fn generate_syntax_construction(
             let _ = writeln!(code, "{indent}let {variant_name} = {struct_name} {{");
             let _ = writeln!(
                 code,
-                "{indent}    default: parse_or_inherit(&[{}], &get_palette_color(palette, &ColorType::from_str(\"{default_color}\")?)?)?,",
+                "{indent}    default: parse_or_inherit(&[{}], &get_palette_color(palette, &ColorType::from_str(\"{default_color}\")?, variant)?)?,",
                 format_parent_chain(&basic_field, &parent_chain)
             );
 

--- a/tinted-builder/src/error.rs
+++ b/tinted-builder/src/error.rs
@@ -91,4 +91,11 @@ pub enum TintedBuilderError {
         target: String,
         supported_derivations: String,
     },
+
+    /// Error indicating an inability to convert from type
+    ///
+    /// This variant is used when attempting to derive a color from another color
+    /// using an unsupported conversion path (e.g., deriving orange from blue).
+    #[error("unable to convert from type: {0}")]
+    UnableToConvertFrom(String),
 }

--- a/tinted-builder/src/scheme.rs
+++ b/tinted-builder/src/scheme.rs
@@ -75,7 +75,7 @@ impl Scheme {
     pub fn get_scheme_variant(&self) -> SchemeVariant {
         match self {
             Self::Base16(scheme) | Self::Base24(scheme) => scheme.variant.clone(),
-            Self::Tinted8(scheme) => scheme.scheme.variant.clone(),
+            Self::Tinted8(scheme) => scheme.variant.clone(),
         }
     }
 }
@@ -138,6 +138,7 @@ impl FromStr for SchemeSystem {
         match system_str {
             "base16" => Ok(Self::Base16),
             "base24" => Ok(Self::Base24),
+            "tinted8" => Ok(Self::Tinted8),
             _ => Err(TintedBuilderError::InvalidSchemeSystem(
                 system_str.to_string(),
             )),

--- a/tinted-builder/src/scheme/color.rs
+++ b/tinted-builder/src/scheme/color.rs
@@ -239,6 +239,44 @@ pub enum ColorName {
     Other, // For unknown colors
 }
 
+impl fmt::Display for ColorName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Black => write!(f, "black"),
+            Self::Red => write!(f, "red"),
+            Self::Green => write!(f, "green"),
+            Self::Yellow => write!(f, "yellow"),
+            Self::Blue => write!(f, "blue"),
+            Self::Magenta => write!(f, "magenta"),
+            Self::Cyan => write!(f, "cyan"),
+            Self::White => write!(f, "white"),
+            Self::Orange => write!(f, "orange"),
+            Self::Gray => write!(f, "gray"),
+            Self::Brown => write!(f, "brown"),
+            Self::Other => write!(f, "other"),
+        }
+    }
+}
+
+impl ColorName {
+    #[must_use]
+    pub const fn get_list<'a>() -> &'a [Self] {
+        &[
+            Self::Black,
+            Self::Red,
+            Self::Green,
+            Self::Yellow,
+            Self::Blue,
+            Self::Magenta,
+            Self::Cyan,
+            Self::White,
+            Self::Orange,
+            Self::Gray,
+            Self::Brown,
+        ]
+    }
+}
+
 pub struct ColorType(pub ColorName, pub ColorVariant);
 
 impl FromStr for ColorName {

--- a/tinted-builder/src/scheme/tinted8/structure.rs
+++ b/tinted-builder/src/scheme/tinted8/structure.rs
@@ -11,7 +11,7 @@ use crate::scheme::tinted8::yaml::Tinted8Scheme as YamlTinted8Scheme;
 use crate::tinted8::SUPPORTED_STYLING_SPEC_VERSION;
 use crate::utils::slugify;
 use crate::utils::titlecasify;
-use crate::SchemeSupports;
+use crate::{SchemeSupports, SchemeVariant};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
@@ -26,6 +26,7 @@ pub struct Scheme {
     pub palette: Palette,
     pub syntax: Syntax,
     pub ui: Ui,
+    pub variant: SchemeVariant,
 }
 
 impl fmt::Display for Scheme {
@@ -46,7 +47,7 @@ impl fmt::Display for Scheme {
         }
         #[allow(clippy::writeln_empty_string)]
         writeln!(f, "")?;
-        writeln!(f, "variant: \"{}\"", self.scheme.variant)?;
+        writeln!(f, "variant: \"{}\"", self.variant)?;
         if let Some(ref family) = self.scheme.family {
             writeln!(f, "family: \"{family}\"")?;
         }
@@ -84,21 +85,23 @@ impl<'de> Deserialize<'de> for Scheme {
         let (name, slug): (String, String) = match (
             &wrapper.scheme.name,
             &wrapper.scheme.slug,
-            &wrapper.family,
-            &wrapper.style,
+            &wrapper.scheme.family,
+            &wrapper.scheme.style,
         ) {
             (Some(name), Some(slug), _, _) => (name.to_owned(), slug.to_owned()),
             (Some(name), None, _, _) => (name.to_owned(), slugify(name)),
             (None, Some(slug), _, _) => (titlecasify(slug), slug.to_owned()),
             (None, None, Some(family), Some(style)) => {
-                let name = format!("{family}-{style}");
+                let display_family = titlecasify(family);
+                let display_style = titlecasify(style);
+                let name = format!("{display_family} {display_style}");
 
                 (name.clone(), slugify(&name))
             }
             (None, None, Some(family), None) => {
-                let name = family.clone();
+                let name = titlecasify(&family.clone());
 
-                (name.clone(), slugify(&name))
+                (name, slugify(&family.clone()))
             }
             _ => {
                 return Err(serde::de::Error::custom(
@@ -109,10 +112,14 @@ impl<'de> Deserialize<'de> for Scheme {
 
         let palette =
             Palette::try_from_basic(&wrapper.palette).map_err(serde::de::Error::custom)?;
-        let ui = Ui::try_from_basic(wrapper.ui.unwrap_or_default(), &palette)
+        let ui = Ui::try_from_basic(&wrapper.ui.unwrap_or_default(), &palette, &wrapper.variant)
             .map_err(serde::de::Error::custom)?;
-        let syntax = Syntax::try_from_basic(&wrapper.syntax.unwrap_or_default(), &palette)
-            .map_err(serde::de::Error::custom)?;
+        let syntax = Syntax::try_from_basic(
+            &wrapper.syntax.unwrap_or_default(),
+            &palette,
+            &wrapper.variant,
+        )
+        .map_err(serde::de::Error::custom)?;
 
         let styling_spec = VersionReq::parse(&wrapper.scheme.supports.styling_spec)
             .map_err(serde::de::Error::custom)?;
@@ -137,13 +144,13 @@ impl<'de> Deserialize<'de> for Scheme {
             description: wrapper.scheme.description,
             theme_author: wrapper.scheme.theme_author.unwrap_or(wrapper.scheme.author),
             supports: SchemeSupports { styling_spec },
-            family: wrapper.family,
-            style: wrapper.style,
-            variant: wrapper.variant,
+            family: wrapper.scheme.family,
+            style: wrapper.scheme.style,
         };
 
         Ok(Self {
             scheme: scheme_meta,
+            variant: wrapper.variant,
             syntax,
             ui,
             palette,

--- a/tinted-builder/src/scheme/tinted8/structure/meta.rs
+++ b/tinted-builder/src/scheme/tinted8/structure/meta.rs
@@ -1,4 +1,4 @@
-use crate::{SchemeSupports, SchemeVariant};
+use crate::SchemeSupports;
 use serde::Serialize;
 
 use crate::SchemeSystem;
@@ -11,7 +11,6 @@ pub struct SchemeMeta {
     pub theme_author: String,
     pub slug: String,
     pub supports: SchemeSupports,
-    pub variant: SchemeVariant,
     pub family: Option<String>,
     pub style: Option<String>,
     pub description: Option<String>,

--- a/tinted-builder/src/scheme/tinted8/structure/palette.rs
+++ b/tinted-builder/src/scheme/tinted8/structure/palette.rs
@@ -12,43 +12,6 @@ use serde::Serialize;
 use std::fmt;
 use thiserror::Error;
 
-impl fmt::Display for ColorName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Black => write!(f, "black"),
-            Self::Red => write!(f, "red"),
-            Self::Green => write!(f, "green"),
-            Self::Yellow => write!(f, "yellow"),
-            Self::Blue => write!(f, "blue"),
-            Self::Magenta => write!(f, "magenta"),
-            Self::Cyan => write!(f, "cyan"),
-            Self::White => write!(f, "white"),
-            Self::Orange => write!(f, "orange"),
-            Self::Gray => write!(f, "gray"),
-            Self::Brown => write!(f, "brown"),
-            Self::Other => write!(f, "other"),
-        }
-    }
-}
-
-impl ColorName {
-    #[must_use]
-    pub const fn get_list<'a>() -> &'a [Self] {
-        &[
-            Self::Black,
-            Self::Red,
-            Self::Green,
-            Self::Yellow,
-            Self::Blue,
-            Self::Magenta,
-            Self::Cyan,
-            Self::White,
-            Self::Orange,
-            Self::Gray,
-            Self::Brown,
-        ]
-    }
-}
 #[derive(Debug, Clone)]
 pub struct Palette {
     pub black_normal: Color,

--- a/tinted-builder/src/scheme/tinted8/structure/syntax.rs
+++ b/tinted-builder/src/scheme/tinted8/structure/syntax.rs
@@ -1,14 +1,18 @@
 use crate::scheme::tinted8::structure::Palette;
-use crate::{Color, ColorName, ColorType, ColorVariant, TintedBuilderError};
+use crate::utils::parse_or_inherit;
+use crate::{Color, ColorName, ColorType, ColorVariant, SchemeVariant, TintedBuilderError};
 use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
-use thiserror::Error;
 include!(concat!(env!("OUT_DIR"), "/syntax_generated.rs"));
 
 impl Syntax {
-    pub fn try_from_basic(basic: &BasicSyntax, palette: &Palette) -> Result<Self, SyntaxError> {
-        generated_try_from_basic(basic, palette)
+    pub fn try_from_basic(
+        basic: &BasicSyntax,
+        palette: &Palette,
+        variant: &SchemeVariant,
+    ) -> Result<Self, TintedBuilderError> {
+        generated_try_from_basic(basic, palette, variant)
     }
 
     pub const fn get_property_list() -> &'static [SyntaxKey] {
@@ -91,6 +95,11 @@ impl Syntax {
             SyntaxKey::PunctuationDefinitionString => &self.punctuation.definition.string,
             SyntaxKey::PunctuationDefinitionComment => &self.punctuation.definition.comment,
             SyntaxKey::PunctuationSection => &self.punctuation.section,
+            SyntaxKey::PunctuationBrackets => &self.punctuation.brackets.default,
+            SyntaxKey::PunctuationBracketsAngle => &self.punctuation.brackets.angle,
+            SyntaxKey::PunctuationBracketsCurly => &self.punctuation.brackets.curly,
+            SyntaxKey::PunctuationBracketsRound => &self.punctuation.brackets.round,
+            SyntaxKey::PunctuationBracketsSquare => &self.punctuation.brackets.square,
             SyntaxKey::Markup => &self.markup.default,
             SyntaxKey::MarkupBold => &self.markup.bold,
             SyntaxKey::MarkupItalic => &self.markup.italic,
@@ -304,9 +313,19 @@ pub struct SyntaxSupportFunction {
 #[derive(Debug, Clone, Serialize)]
 pub struct SyntaxPunctuation {
     pub default: Color,
+    pub brackets: SyntaxPunctuationBrackets,
     pub separator: Color,
     pub definition: SyntaxPunctuationDefinition,
     pub section: Color,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntaxPunctuationBrackets {
+    pub default: Color,
+    pub angle: Color,
+    pub curly: Color,
+    pub round: Color,
+    pub square: Color,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -359,43 +378,4 @@ pub struct SyntaxMeta {
     pub preprocessor: Color,
     pub embedded: Color,
     pub object: Color,
-}
-
-#[derive(Error, Debug)]
-pub enum SyntaxError {
-    #[error("unable to convert from type: {0}")]
-    UnableToConvertFrom(String),
-}
-
-impl From<TintedBuilderError> for SyntaxError {
-    fn from(error: TintedBuilderError) -> Self {
-        Self::UnableToConvertFrom(error.to_string())
-    }
-}
-
-/// Parse a color with parent inheritance semantics.
-///
-/// Resolution order:
-/// 1. Use and parse `value` if provided.
-/// 2. Otherwise, use `parent` if provided (parsed via `parse_or_inherit`).
-/// 3. Otherwise, fall back to `default`.
-///
-/// This supports cases like `string.quoted` inheriting from `string` when the
-/// child value is omitted.
-///
-/// Errors
-/// Returns `SyntaxError::UnableToConvertFrom` if a provided string cannot be
-/// parsed into a `Color`.
-fn parse_or_inherit(value_list: &[Option<&str>], default: &Color) -> Result<Color, SyntaxError> {
-    let value_list: Vec<String> = value_list
-        .iter()
-        .filter_map(|s| s.map(std::string::ToString::to_string))
-        .collect();
-
-    value_list.first().map_or_else(
-        || Ok(default.clone()),
-        |val| {
-            Color::new(val, None, None).map_err(|e| SyntaxError::UnableToConvertFrom(e.to_string()))
-        },
-    )
 }

--- a/tinted-builder/src/scheme/tinted8/structure/ui.rs
+++ b/tinted-builder/src/scheme/tinted8/structure/ui.rs
@@ -1,9 +1,9 @@
 use serde::Serialize;
-use thiserror::Error;
 
 use crate::{
     scheme::tinted8::{yaml::BasicUi, Palette},
-    Color,
+    utils::parse_or_inherit,
+    Color, SchemeVariant, TintedBuilderError,
 };
 use std::fmt;
 
@@ -37,7 +37,8 @@ define_ui_keys! {
     Deprecated => "deprecated",
     Accent => "accent",
     Border => "border",
-    Cursor => "cursor",
+    CursorNormal => "cursor.normal",
+    CursorMuted => "cursor.muted",
     GlobalForegroundNormal => "global.foreground.normal",
     GlobalForegroundDark => "global.foreground.dark",
     GlobalForegroundLight => "global.foreground.light",
@@ -81,7 +82,7 @@ pub struct Ui {
     pub deprecated: Color,
     pub accent: Color,
     pub border: Color,
-    pub cursor: Color,
+    pub cursor: UiCursor,
     pub global: UiGlobal,
     pub gutter: UiBgFg,
     pub highlight: UiHighlight,
@@ -95,16 +96,31 @@ pub struct Ui {
 }
 
 impl Ui {
-    pub fn new(palette: &Palette) -> Self {
-        let background = UiGlobalBackground {
-            normal: palette.black_normal.clone(),
-            dark: palette.black_dim.clone(),
-            light: palette.black_bright.clone(),
+    #[allow(clippy::too_many_lines)]
+    pub fn new(palette: &Palette, variant: &SchemeVariant) -> Self {
+        let background = match variant {
+            SchemeVariant::Dark => UiGlobalBackground {
+                normal: palette.black_normal.clone(),
+                dark: palette.black_dim.clone(),
+                light: palette.black_bright.clone(),
+            },
+            SchemeVariant::Light => UiGlobalBackground {
+                normal: palette.white_normal.clone(),
+                dark: palette.white_dim.clone(),
+                light: palette.white_bright.clone(),
+            },
         };
-        let foreground = UiGlobalForeground {
-            normal: palette.white_normal.clone(),
-            dark: palette.white_dim.clone(),
-            light: palette.white_bright.clone(),
+        let foreground = match variant {
+            SchemeVariant::Dark => UiGlobalForeground {
+                normal: palette.white_normal.clone(),
+                dark: palette.white_dim.clone(),
+                light: palette.white_bright.clone(),
+            },
+            SchemeVariant::Light => UiGlobalForeground {
+                normal: palette.black_normal.clone(),
+                dark: palette.black_dim.clone(),
+                light: palette.black_bright.clone(),
+            },
         };
         let global = UiGlobal {
             background: background.clone(),
@@ -114,38 +130,82 @@ impl Ui {
             background: background.normal.clone(),
             foreground: foreground.dark.clone(),
         };
-        let highlight = UiHighlight {
-            button: UiBgFg {
-                background: palette.black_bright.clone(),
-                foreground: palette.white_normal.clone(),
+        let highlight = match variant {
+            SchemeVariant::Dark => UiHighlight {
+                button: UiBgFg {
+                    background: palette.black_bright.clone(),
+                    foreground: palette.white_normal.clone(),
+                },
+                line: UiBgFg {
+                    background: palette.gray_dim.clone(),
+                    foreground: palette.white_dim.clone(),
+                },
+                text: UiHighlightText {
+                    background: palette.gray_dim.clone(),
+                    foreground: palette.white_normal.clone(),
+                    active_background: palette.gray_normal.clone(),
+                    active_foreground: palette.white_normal.clone(),
+                },
+                search: UiBgFg {
+                    background: palette.black_bright.clone(),
+                    foreground: palette.yellow_normal.clone(),
+                },
             },
-            line: UiBgFg {
-                background: palette.gray_dim.clone(),
-                foreground: palette.white_dim.clone(),
-            },
-            text: UiHighlightText {
-                background: palette.gray_dim.clone(),
-                foreground: palette.white_normal.clone(),
-                active_background: palette.gray_normal.clone(),
-                active_foreground: palette.white_normal.clone(),
-            },
-            search: UiBgFg {
-                background: palette.black_bright.clone(),
-                foreground: palette.yellow_normal.clone(),
+            SchemeVariant::Light => UiHighlight {
+                button: UiBgFg {
+                    background: palette.white_dim.clone(),
+                    foreground: palette.black_normal.clone(),
+                },
+                line: UiBgFg {
+                    background: palette.gray_bright.clone(),
+                    foreground: palette.black_bright.clone(),
+                },
+                text: UiHighlightText {
+                    background: palette.gray_dim.clone(),
+                    foreground: palette.black_normal.clone(),
+                    active_background: palette.gray_normal.clone(),
+                    active_foreground: palette.black_normal.clone(),
+                },
+                search: UiBgFg {
+                    background: palette.white_dim.clone(),
+                    foreground: palette.yellow_normal.clone(),
+                },
             },
         };
-        let indent_guide = UiIndentGuide {
-            background: background.light,
-            active_background: palette.gray_dim.clone(),
+        let indent_guide = match variant {
+            SchemeVariant::Dark => UiIndentGuide {
+                background: background.light,
+                active_background: palette.gray_dim.clone(),
+            },
+            SchemeVariant::Light => UiIndentGuide {
+                background: background.light,
+                active_background: palette.gray_bright.clone(),
+            },
         };
-        let selection = UiSelection {
-            background: palette.black_bright.clone(),
-            foreground: palette.white_normal.clone(),
-            inactive_background: palette.black_bright.clone(),
+        let selection = match variant {
+            SchemeVariant::Dark => UiSelection {
+                background: palette.black_bright.clone(),
+                foreground: palette.white_normal.clone(),
+                inactive_background: palette.black_bright.clone(),
+            },
+            SchemeVariant::Light => UiSelection {
+                background: palette.white_dim.clone(),
+                foreground: palette.black_normal.clone(),
+                inactive_background: palette.white_dim.clone(),
+            },
         };
         let accent = palette.cyan_normal.clone();
         let border = palette.gray_dim.clone();
-        let cursor = foreground.normal.clone();
+        let cursor = match variant {
+            SchemeVariant::Dark => UiCursor {
+                normal: foreground.normal.clone(),
+                muted: palette.gray_bright.clone(),
+            },
+            SchemeVariant::Light => UiCursor {
+                normal: foreground.normal.clone(),
+                muted: palette.gray_dim.clone(),
+            },
+        };
         let link = palette.cyan_normal.clone();
         let status = UiStatus {
             error: palette.red_normal.clone(),
@@ -153,9 +213,15 @@ impl Ui {
             success: palette.green_normal.clone(),
             warning: palette.yellow_normal.clone(),
         };
-        let tooltip = UiBgFg {
-            background: palette.black_dim.clone(),
-            foreground: foreground.normal,
+        let tooltip = match variant {
+            SchemeVariant::Dark => UiBgFg {
+                background: palette.black_dim.clone(),
+                foreground: foreground.normal,
+            },
+            SchemeVariant::Light => UiBgFg {
+                background: palette.white_bright.clone(),
+                foreground: foreground.normal,
+            },
         };
         let whitespace = UiWhitespace {
             foreground: palette.gray_normal.clone(),
@@ -178,55 +244,41 @@ impl Ui {
         }
     }
     #[allow(clippy::too_many_lines)]
-    pub fn try_from_basic(basic: BasicUi, palette: &Palette) -> Result<Self, UiError> {
-        let default = Self::new(palette);
+    pub fn try_from_basic(
+        basic: &BasicUi,
+        palette: &Palette,
+        variant: &SchemeVariant,
+    ) -> Result<Self, TintedBuilderError> {
+        let default = Self::new(palette, variant);
 
         let background = UiGlobalBackground {
-            normal: basic
-                .global_background_normal
-                .map_or_else(
-                    || Ok(default.global.background.normal),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            dark: basic
-                .global_background_dark
-                .map_or_else(
-                    || Ok(default.global.background.dark),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            light: basic
-                .global_background_light
-                .map_or_else(
-                    || Ok(default.global.background.light),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            normal: parse_or_inherit(
+                &[basic.global_background_normal.as_deref()],
+                &default.global.background.normal,
+            )?,
+            dark: parse_or_inherit(
+                &[basic.global_background_dark.as_deref()],
+                &default.global.background.dark,
+            )?,
+            light: parse_or_inherit(
+                &[basic.global_background_light.as_deref()],
+                &default.global.background.light,
+            )?,
         };
 
         let foreground = UiGlobalForeground {
-            normal: basic
-                .global_foreground_normal
-                .map_or_else(
-                    || Ok(default.global.foreground.normal),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            dark: basic
-                .global_foreground_dark
-                .map_or_else(
-                    || Ok(default.global.foreground.dark),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            light: basic
-                .global_foreground_light
-                .map_or_else(
-                    || Ok(default.global.foreground.light),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            normal: parse_or_inherit(
+                &[basic.global_foreground_normal.as_deref()],
+                &default.global.foreground.normal,
+            )?,
+            dark: parse_or_inherit(
+                &[basic.global_foreground_dark.as_deref()],
+                &default.global.foreground.dark,
+            )?,
+            light: parse_or_inherit(
+                &[basic.global_foreground_light.as_deref()],
+                &default.global.foreground.light,
+            )?,
         };
         let global = UiGlobal {
             background,
@@ -234,99 +286,63 @@ impl Ui {
         };
 
         let gutter = UiBgFg {
-            background: basic
-                .gutter_background
-                .map_or_else(
-                    || Ok(default.gutter.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .gutter_foreground
-                .map_or_else(
-                    || Ok(default.gutter.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.gutter_background.as_deref()],
+                &default.gutter.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.gutter_foreground.as_deref()],
+                &default.gutter.foreground,
+            )?,
         };
 
         let highlight_button = UiBgFg {
-            background: basic
-                .highlight_button_background
-                .map_or_else(
-                    || Ok(default.highlight.button.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .highlight_button_foreground
-                .map_or_else(
-                    || Ok(default.highlight.button.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.highlight_button_background.as_deref()],
+                &default.highlight.button.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.highlight_button_foreground.as_deref()],
+                &default.highlight.button.foreground,
+            )?,
         };
         let highlight_text = UiHighlightText {
-            background: basic
-                .highlight_text_background
-                .map_or_else(
-                    || Ok(default.highlight.text.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .highlight_text_foreground
-                .map_or_else(
-                    || Ok(default.highlight.text.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            active_background: basic
-                .highlight_text_active_background
-                .map_or_else(
-                    || Ok(default.highlight.text.active_background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            active_foreground: basic
-                .highlight_text_active_foreground
-                .map_or_else(
-                    || Ok(default.highlight.text.active_foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.highlight_text_background.as_deref()],
+                &default.highlight.text.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.highlight_text_foreground.as_deref()],
+                &default.highlight.text.foreground,
+            )?,
+            active_background: parse_or_inherit(
+                &[basic.highlight_text_active_background.as_deref()],
+                &default.highlight.text.active_background,
+            )?,
+            active_foreground: parse_or_inherit(
+                &[basic.highlight_text_active_foreground.as_deref()],
+                &default.highlight.text.active_foreground,
+            )?,
         };
         let highlight_line = UiBgFg {
-            background: basic
-                .highlight_line_background
-                .map_or_else(
-                    || Ok(default.highlight.line.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .highlight_line_foreground
-                .map_or_else(
-                    || Ok(default.highlight.line.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.highlight_line_background.as_deref()],
+                &default.highlight.line.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.highlight_line_foreground.as_deref()],
+                &default.highlight.line.foreground,
+            )?,
         };
         let highlight_search = UiBgFg {
-            background: basic
-                .highlight_search_background
-                .map_or_else(
-                    || Ok(default.highlight.search.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .highlight_search_foreground
-                .map_or_else(
-                    || Ok(default.highlight.search.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.highlight_search_background.as_deref()],
+                &default.highlight.search.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.highlight_search_foreground.as_deref()],
+                &default.highlight.search.foreground,
+            )?,
         };
 
         let highlight = UiHighlight {
@@ -337,126 +353,75 @@ impl Ui {
         };
 
         let indent_guide = UiIndentGuide {
-            background: basic
-                .indent_guide_background
-                .map_or_else(
-                    || Ok(default.indent_guide.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            active_background: basic
-                .indent_guide_active_background
-                .map_or_else(
-                    || Ok(default.indent_guide.active_background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.indent_guide_background.as_deref()],
+                &default.indent_guide.background,
+            )?,
+            active_background: parse_or_inherit(
+                &[basic.indent_guide_active_background.as_deref()],
+                &default.indent_guide.active_background,
+            )?,
         };
 
         let selection = UiSelection {
-            background: basic
-                .selection_background
-                .map_or_else(
-                    || Ok(default.selection.background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            foreground: basic
-                .selection_foreground
-                .map_or_else(
-                    || Ok(default.selection.foreground),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            inactive_background: basic
-                .selection_inactive_background
-                .map_or_else(
-                    || Ok(default.selection.inactive_background),
-                    |ref s| Color::new(s, None, None),
-                )
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            background: parse_or_inherit(
+                &[basic.selection_background.as_deref()],
+                &default.selection.background,
+            )?,
+            foreground: parse_or_inherit(
+                &[basic.selection_foreground.as_deref()],
+                &default.selection.foreground,
+            )?,
+            inactive_background: parse_or_inherit(
+                &[basic.selection_inactive_background.as_deref()],
+                &default.selection.inactive_background,
+            )?,
         };
 
         Ok(Self {
             global,
-            deprecated: basic
-                .deprecated
-                .map_or_else(|| Ok(default.deprecated), |ref s| Color::new(s, None, None))
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            accent: basic
-                .accent
-                .map_or_else(|| Ok(default.accent), |ref s| Color::new(s, None, None))
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            border: basic
-                .border
-                .map_or_else(|| Ok(default.border), |ref s| Color::new(s, None, None))
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-            cursor: basic
-                .cursor
-                .map_or_else(|| Ok(default.cursor), |ref s| Color::new(s, None, None))
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            deprecated: parse_or_inherit(&[basic.deprecated.as_deref()], &default.deprecated)?,
+            accent: parse_or_inherit(&[basic.accent.as_deref()], &default.accent)?,
+            border: parse_or_inherit(&[basic.border.as_deref()], &default.border)?,
+            cursor: UiCursor {
+                normal: parse_or_inherit(
+                    &[basic.cursor_normal.as_deref()],
+                    &default.cursor.normal,
+                )?,
+                muted: parse_or_inherit(&[basic.cursor_muted.as_deref()], &default.cursor.muted)?,
+            },
             gutter,
             highlight,
             indent_guide,
-            link: basic
-                .link
-                .map_or_else(|| Ok(default.link), |ref s| Color::new(s, None, None))
-                .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+            link: parse_or_inherit(&[basic.link.as_deref()], &default.link)?,
             selection,
             status: UiStatus {
-                error: basic
-                    .status_error
-                    .map_or_else(
-                        || Ok(default.status.error),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-                info: basic
-                    .status_info
-                    .map_or_else(
-                        || Ok(default.status.info),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-                success: basic
-                    .status_success
-                    .map_or_else(
-                        || Ok(default.status.success),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-                warning: basic
-                    .status_warning
-                    .map_or_else(
-                        || Ok(default.status.warning),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+                error: parse_or_inherit(&[basic.status_error.as_deref()], &default.status.error)?,
+                info: parse_or_inherit(&[basic.status_info.as_deref()], &default.status.info)?,
+                success: parse_or_inherit(
+                    &[basic.status_success.as_deref()],
+                    &default.status.success,
+                )?,
+                warning: parse_or_inherit(
+                    &[basic.status_warning.as_deref()],
+                    &default.status.warning,
+                )?,
             },
             tooltip: UiBgFg {
-                background: basic
-                    .tooltip_background
-                    .map_or_else(
-                        || Ok(default.tooltip.background),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
-                foreground: basic
-                    .tooltip_foreground
-                    .map_or_else(
-                        || Ok(default.tooltip.foreground),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+                background: parse_or_inherit(
+                    &[basic.tooltip_background.as_deref()],
+                    &default.tooltip.background,
+                )?,
+                foreground: parse_or_inherit(
+                    &[basic.tooltip_foreground.as_deref()],
+                    &default.tooltip.foreground,
+                )?,
             },
             whitespace: UiWhitespace {
-                foreground: basic
-                    .whitespace_foreground
-                    .map_or_else(
-                        || Ok(default.whitespace.foreground),
-                        |ref s| Color::new(s, None, None),
-                    )
-                    .map_err(|err| UiError::UnableToConvertFrom(err.to_string()))?,
+                foreground: parse_or_inherit(
+                    &[basic.whitespace_foreground.as_deref()],
+                    &default.whitespace.foreground,
+                )?,
             },
         })
     }
@@ -469,7 +434,8 @@ impl Ui {
             UiKey::Deprecated => &self.deprecated,
             UiKey::Accent => &self.accent,
             UiKey::Border => &self.border,
-            UiKey::Cursor => &self.cursor,
+            UiKey::CursorNormal => &self.cursor.normal,
+            UiKey::CursorMuted => &self.cursor.muted,
             UiKey::GlobalForegroundNormal => &self.global.foreground.normal,
             UiKey::GlobalForegroundDark => &self.global.foreground.dark,
             UiKey::GlobalForegroundLight => &self.global.foreground.light,
@@ -510,12 +476,6 @@ impl fmt::Display for Ui {
 
         Ok(())
     }
-}
-
-#[derive(Error, Debug)]
-pub enum UiError {
-    #[error("unable to convert from type: {0}")]
-    UnableToConvertFrom(String),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -568,6 +528,11 @@ pub struct UiSelection {
     pub foreground: Color,
     #[serde(rename = "inactive-background")]
     pub inactive_background: Color,
+}
+#[derive(Debug, Clone, Serialize)]
+pub struct UiCursor {
+    pub normal: Color,
+    pub muted: Color,
 }
 #[derive(Debug, Clone, Serialize)]
 pub struct UiStatus {

--- a/tinted-builder/src/scheme/tinted8/syntax_schema.yaml
+++ b/tinted-builder/src/scheme/tinted8/syntax_schema.yaml
@@ -211,6 +211,18 @@ syntax:
       - key: section
         scope: punctuation.section
         default: orange_normal
+      - key: brackets
+        scope: punctuation.brackets
+        default: orange_normal
+        children:
+          - key: angle
+            scope: punctuation.brackets.angle
+          - key: curly
+            scope: punctuation.brackets.curly
+          - key: round
+            scope: punctuation.brackets.round
+          - key: square
+            scope: punctuation.brackets.square
 
   - key: markup
     scope: markup

--- a/tinted-builder/src/scheme/tinted8/yaml.rs
+++ b/tinted-builder/src/scheme/tinted8/yaml.rs
@@ -8,12 +8,9 @@ use std::fmt;
 pub struct Tinted8Scheme {
     pub scheme: Meta,
     pub palette: BasicPalette,
-    pub variant: SchemeVariant,
-
     pub syntax: Option<BasicSyntax>,
     pub ui: Option<BasicUi>,
-    pub family: Option<String>,
-    pub style: Option<String>,
+    pub variant: SchemeVariant,
 }
 
 // Helper type that mirrors `Tinted8Scheme` for inner deserialization.
@@ -21,12 +18,9 @@ pub struct Tinted8Scheme {
 struct Tinted8SchemeHelper {
     pub scheme: Meta,
     pub palette: BasicPalette,
-    pub variant: SchemeVariant,
-
     pub syntax: Option<BasicSyntax>,
     pub ui: Option<BasicUi>,
-    pub family: Option<String>,
-    pub style: Option<String>,
+    pub variant: SchemeVariant,
 }
 
 impl From<Tinted8SchemeHelper> for Tinted8Scheme {
@@ -34,11 +28,9 @@ impl From<Tinted8SchemeHelper> for Tinted8Scheme {
         Self {
             scheme: h.scheme,
             palette: h.palette,
-            variant: h.variant,
             syntax: h.syntax,
             ui: h.ui,
-            family: h.family,
-            style: h.style,
+            variant: h.variant,
         }
     }
 }
@@ -137,8 +129,10 @@ pub struct BasicUi {
     pub accent: Option<String>,
     #[serde(rename = "border")]
     pub border: Option<String>,
-    #[serde(rename = "cursor")]
-    pub cursor: Option<String>,
+    #[serde(rename = "cursor.normal")]
+    pub cursor_normal: Option<String>,
+    #[serde(rename = "cursor.muted")]
+    pub cursor_muted: Option<String>,
     #[serde(rename = "global.foreground.normal")]
     pub global_foreground_normal: Option<String>,
     #[serde(rename = "global.foreground.dark")]
@@ -309,4 +303,6 @@ pub struct Meta {
     pub theme_author: Option<String>,
     pub slug: Option<String>,
     pub description: Option<String>,
+    pub family: Option<String>,
+    pub style: Option<String>,
 }

--- a/tinted-builder/src/template/tinted8.rs
+++ b/tinted-builder/src/template/tinted8.rs
@@ -2,7 +2,6 @@ use crate::{
     error::TintedBuilderError, tinted8::Scheme as Tinted8Scheme, SchemeSupports, SchemeVariant,
 };
 use serde::Serialize;
-use std::str::FromStr;
 
 /// Render a template with any serializable context.
 ///
@@ -28,10 +27,13 @@ struct SchemeMetaCtx {
     #[serde(rename = "slug-underscored")]
     slug_underscored: String,
     system: String,
-    variant: String,
     supports: SchemeSupports,
     family: String,
     style: String,
+}
+
+#[derive(Serialize)]
+struct OptionCtx {
     #[serde(rename = "is-dark-variant")]
     is_dark_variant: bool,
 }
@@ -42,6 +44,8 @@ struct TemplateCtx<'a> {
     palette: &'a crate::scheme::tinted8::structure::Palette,
     syntax: &'a crate::scheme::tinted8::structure::Syntax,
     ui: &'a crate::scheme::tinted8::structure::Ui,
+    variant: &'a SchemeVariant,
+    option: &'a OptionCtx,
 }
 
 /// Builds a structured YAML context for Tinted8 templates.
@@ -57,7 +61,6 @@ pub fn to_template_context(
         name: meta.name.clone(),
         author: meta.author.clone(),
         description: meta.description.clone().unwrap_or_default(),
-        variant: meta.variant.to_string(),
         slug: meta.slug.clone(),
         slug_underscored: meta.slug.replace('-', "_"),
         system: meta.system.to_string(),
@@ -66,7 +69,10 @@ pub fn to_template_context(
         },
         family: meta.family.clone().unwrap_or_default(),
         style: meta.style.clone().unwrap_or_default(),
-        is_dark_variant: SchemeVariant::from_str(meta.variant.as_str())? == SchemeVariant::Dark,
+    };
+    let variant = &scheme.variant;
+    let option = &OptionCtx {
+        is_dark_variant: *variant == SchemeVariant::Dark,
     };
 
     let ctx = TemplateCtx {
@@ -74,6 +80,8 @@ pub fn to_template_context(
         palette: &scheme.palette,
         syntax: &scheme.syntax,
         ui: &scheme.ui,
+        variant,
+        option,
     };
 
     Ok(serde_yaml::to_value(&ctx)?)

--- a/tinted-builder/src/utils.rs
+++ b/tinted-builder/src/utils.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use std::collections::HashMap;
 
+use crate::{Color, TintedBuilderError};
+
 /// Slugifies a string using ASCII-only, kebab-case output.
 ///
 /// Examples:
@@ -97,6 +99,37 @@ pub fn titlecasify(input: &str) -> String {
         })
         .collect::<Vec<String>>()
         .join(" ")
+}
+
+/// Parse a color with parent inheritance semantics.
+///
+/// Resolution order:
+/// 1. Use and parse `value` if provided.
+/// 2. Otherwise, use `parent` if provided (parsed via `parse_or_inherit`).
+/// 3. Otherwise, fall back to `default`.
+///
+/// This supports cases like `string.quoted` inheriting from `string` when the
+/// child value is omitted.
+///
+/// Errors
+/// Returns `SyntaxError::UnableToConvertFrom` if a provided string cannot be
+/// parsed into a `Color`.
+pub fn parse_or_inherit(
+    value_list: &[Option<&str>],
+    default: &Color,
+) -> Result<Color, TintedBuilderError> {
+    let value_list: Vec<String> = value_list
+        .iter()
+        .filter_map(|s| s.map(std::string::ToString::to_string))
+        .collect();
+
+    value_list.first().map_or_else(
+        || Ok(default.clone()),
+        |val| {
+            Color::new(val, None, None)
+                .map_err(|e| TintedBuilderError::UnableToConvertFrom(e.to_string()))
+        },
+    )
 }
 
 #[cfg(test)]

--- a/tinted-builder/tests/general.rs
+++ b/tinted-builder/tests/general.rs
@@ -117,7 +117,7 @@ fn render_dec() -> Result<()> {
 #[test]
 fn render_is_dark_variant() -> Result<()> {
     let template_source =
-        "{{#scheme.is-dark-variant}}it is a dark variant!{{/scheme.is-dark-variant}}";
+        "{{#option.is-dark-variant}}it is a dark variant!{{/option.is-dark-variant}}";
     let scheme = Scheme::Tinted8(serde_yaml::from_str(SCHEME_TINTED_CATPPUCCIN_MOCHA)?);
     let template = Template::new(template_source.to_string(), scheme);
 

--- a/tinted-builder/tests/tinted8.rs
+++ b/tinted-builder/tests/tinted8.rs
@@ -17,7 +17,7 @@ fn deserialize_minimal_scheme() -> Result<(), TintedBuilderError> {
 fn deserialize_family_style_derives_name() -> Result<(), TintedBuilderError> {
     let ts: Tinted8Scheme = serde_yaml::from_str(SCHEME_WITH_FAMILY_STYLE)?;
 
-    assert_eq!(ts.scheme.name, "Ayu-Mirage");
+    assert_eq!(ts.scheme.name, "Ayu Mirage");
     assert_eq!(ts.scheme.slug, "ayu-mirage");
     assert_eq!(ts.scheme.family, Some("Ayu".to_string()));
     assert_eq!(ts.scheme.style, Some("Mirage".to_string()));
@@ -222,9 +222,9 @@ scheme:
   author: "Test Author"
   supports:
     styling-spec: "0.2.0"
+  family: "Ayu"
+  style: "Mirage"
 variant: "light"
-family: "Ayu"
-style: "Mirage"
 palette:
   black:   "#131721"
   red:     "#f07178"


### PR DESCRIPTION
- Add tinted8 0.2.0-beta3 feature where the default colour values of grayscale colors are different based on whether a dark or light scheme variant is active
- Add `ui.cursor_muted`
- Change `ui.cursor` to `ui.cursor_normal`
- Move scheme `family` and `style` into `scheme.meta` `Tinted8Scheme` struct
- Move `family` and `style` into `scheme` object in yaml file
- Fix bug where tinted8 scheme.name isn't correctly titlecasified
- Fix bug where `FromStr` is not implemented for `tinted8`