### PR TITLE
lib: expose tinted8::UiKey publicly

### DIFF
--- a/tinted-builder/CHANGELOG.md
+++ b/tinted-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Re-export `tinted8::UiKey` so downstream crates can iterate UI keys the
+  same way they already do with `tinted8::SyntaxKey`.
+
 ## [0.14.0] - 21-04-2026
 
 ### Changed

--- a/tinted-builder/src/lib.rs
+++ b/tinted-builder/src/lib.rs
@@ -34,6 +34,7 @@ pub mod tinted8 {
     /// - `SUPPORTED_STYLING_SPEC_VERSION` / `SUPPORTED_BUILDER_SPEC_VERSION`: version strings the
     ///   library targets; useful for compatibility checks.
     pub use crate::scheme::tinted8::{
-        Palette, Scheme, SyntaxKey, SUPPORTED_BUILDER_SPEC_VERSION, SUPPORTED_STYLING_SPEC_VERSION,
+        Palette, Scheme, SyntaxKey, UiKey, SUPPORTED_BUILDER_SPEC_VERSION,
+        SUPPORTED_STYLING_SPEC_VERSION,
     };
 }

--- a/tinted-builder/src/scheme/tinted8.rs
+++ b/tinted-builder/src/scheme/tinted8.rs
@@ -1,7 +1,7 @@
 pub mod structure;
 mod yaml;
 
-pub use crate::scheme::tinted8::structure::{Palette, Scheme, SyntaxKey};
+pub use crate::scheme::tinted8::structure::{Palette, Scheme, SyntaxKey, UiKey};
 use crate::SchemeSystem;
 
 pub const SUPPORTED_BUILDER_SPEC_VERSION: &str = "0.2.0";

--- a/tinted-builder/src/scheme/tinted8/structure.rs
+++ b/tinted-builder/src/scheme/tinted8/structure.rs
@@ -6,7 +6,7 @@ pub mod ui;
 pub use crate::scheme::tinted8::structure::meta::SchemeMeta;
 pub use crate::scheme::tinted8::structure::palette::Palette;
 pub use crate::scheme::tinted8::structure::syntax::{Syntax, SyntaxKey};
-pub use crate::scheme::tinted8::structure::ui::Ui;
+pub use crate::scheme::tinted8::structure::ui::{Ui, UiKey};
 use crate::scheme::tinted8::yaml::Tinted8Scheme as YamlTinted8Scheme;
 use crate::tinted8::SUPPORTED_STYLING_SPEC_VERSION;
 use crate::utils::slugify;

--- a/tinted-builder/tests/tinted8.rs
+++ b/tinted-builder/tests/tinted8.rs
@@ -352,6 +352,55 @@ fn syntax_all_keys_accessible() -> Result<(), TintedBuilderError> {
 }
 
 #[test]
+fn ui_all_keys_accessible() -> Result<(), TintedBuilderError> {
+    use tinted_builder::tinted8::UiKey;
+
+    let scheme: Tinted8Scheme = serde_yaml::from_str(SCHEME_MINIMAL)?;
+
+    for key in UiKey::variants() {
+        let color = scheme.ui.get_color(key);
+        assert!(!color.to_hex().is_empty(), "Key {key} should have a color");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn ui_key_display_uses_dotted_paths() {
+    use tinted_builder::tinted8::UiKey;
+
+    let rendered: Vec<String> = UiKey::variants().iter().map(ToString::to_string).collect();
+
+    assert!(rendered.contains(&"global.background.normal".to_string()));
+    assert!(rendered.contains(&"global.foreground.normal".to_string()));
+    assert!(rendered.contains(&"selection.background".to_string()));
+    assert!(rendered.contains(&"highlight.text.active-foreground".to_string()));
+    assert!(rendered.contains(&"indent-guide.active-background".to_string()));
+}
+
+#[test]
+fn ui_key_overrides_resolve_via_get_color() -> Result<(), TintedBuilderError> {
+    use tinted_builder::tinted8::UiKey;
+
+    let scheme: Tinted8Scheme = serde_yaml::from_str(SCHEME_WITH_UI)?;
+
+    assert_eq!(
+        scheme.ui.get_color(&UiKey::GlobalBackgroundNormal).to_hex(),
+        "111111"
+    );
+    assert_eq!(
+        scheme.ui.get_color(&UiKey::GlobalForegroundNormal).to_hex(),
+        "eeeeee"
+    );
+    assert_eq!(
+        scheme.ui.get_color(&UiKey::GlobalBackgroundDark).to_hex(),
+        "000000"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn syntax_new_scopes_parse_correctly() -> Result<(), TintedBuilderError> {
     let scheme: Tinted8Scheme = serde_yaml::from_str(SCHEME_WITH_NEW_SCOPES)?;
 


### PR DESCRIPTION
## Summary

`SyntaxKey` is already publicly re-exported from `tinted_builder::tinted8`, which lets downstream crates iterate every syntax key (`SyntaxKey::variants()`) and look up colors (`Syntax::get_color(&key)`). The parallel `UiKey` enum exists in `scheme/tinted8/structure/ui.rs` and `Ui::get_color(&UiKey)` is `pub`, but `UiKey` itself isn't re-exported anywhere on the public surface, so downstream consumers can't iterate UI keys the same way.

This PR re-exports `UiKey` alongside `SyntaxKey` in the three locations that already expose `SyntaxKey`:

- `tinted-builder/src/scheme/tinted8/structure.rs`
- `tinted-builder/src/scheme/tinted8.rs`
- `tinted-builder/src/lib.rs`

No behavior change. Added new tests covering the new surface.

### Motivation

Working on a Tinty feature that exposes every Tinted8 UI and Syntax color in `tinty list --json` to enhance the information available for `tinty gallery` UI. The Syntax half is straightforward thanks to `SyntaxKey::variants()` — the UI half currently requires hardcoding the canonical UI key list in Tinty's source, which drifts as the spec evolves (e.g. between lib 0.13 and 0.14 several UI keys were renamed). Exposing `UiKey` lets downstream code iterate symmetrically.

## Test plan

- [x] `cargo check -p tinted-builder` passes
- [x] `cargo test -p tinted-builder --lib` passes
- [x] `cargo test -p tinted-builder --test tinted8`