### PR TITLE
fix(build): E111 build failure on non-scheme files in the schemes directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `build` no longer fails with `E111` on non-scheme files in the schemes
+  directory (e.g. `LICENSE`, `README.md`) or on hidden entries such as
+  `.yamllint.yml` / `.github/**`; these are skipped during discovery. Files
+  with an unrecognized extension *inside* a `base16`/`base24`/`tinted8`
+  directory still surface an error.
+
+### Added
+
+- Expose `get_scheme_files_by_name()` for `<system>/`-subdir keyed scheme
+  discovery, so downstreams can share one walker implementation.
+
 ## [0.20.1] - 2026-05-04
 
 ### Fixed

--- a/tinted-builder-rust/src/lib.rs
+++ b/tinted-builder-rust/src/lib.rs
@@ -7,7 +7,7 @@ pub mod operations {
 mod helpers;
 
 pub mod utils {
-    pub use crate::operations::build::utils::get_scheme_files;
+    pub use crate::operations::build::utils::{get_scheme_files, get_scheme_files_by_name};
 }
 
 pub use crate::operations::build as operation_build;

--- a/tinted-builder-rust/src/operations/build/utils.rs
+++ b/tinted-builder-rust/src/operations/build/utils.rs
@@ -164,14 +164,17 @@ impl ParsedFilename {
 /// represents a valid scheme file. If any error occurs during directory traversal or file handling,
 /// an `Err` with the relevant error information is returned.
 ///
+/// Strictness depends on directory layout: a file directly inside a scheme-system directory
+/// (`base16`/`base24`/`tinted8`) must be a valid scheme file, while unrecognized files elsewhere
+/// (e.g. at the root) are treated as non-schemes and skipped.
+///
 /// # Errors
 ///
 /// This function can return an error in the following scenarios:
 ///
 /// * If the directory cannot be read.
 /// * If there is an issue accessing the contents of the directory.
-/// * If there is an issue creating a `SchemeFile` from a file path.
-///   Recursively collects scheme files from a directory, skipping hidden files/dirs.
+/// * If an unrecognized file is found inside a scheme-system directory.
 pub fn get_scheme_files(
     dirpath: impl AsRef<Path>,
     ignores: &[String],
@@ -182,35 +185,66 @@ pub fn get_scheme_files(
         .map(|s| Glob::new(s))
         .collect::<Result<_, _>>()?;
 
+    // Strictness is keyed off directory layout: files directly inside a scheme-system
+    // directory (`base16`/`base24`/`tinted8`) must be valid scheme files, while at the
+    // root (or any non-system directory) unrecognized files are simply not schemes and
+    // are skipped. This lets a schemes repo carry `LICENSE`, `README.md`, etc. without
+    // breaking discovery, while still surfacing genuinely misplaced files.
+    let strict = dir_is_scheme_system(dirpath.as_ref());
+
+    collect_scheme_files(dirpath, &glob_ignores, is_recursive, strict)
+}
+
+/// Returns `true` when the directory's own name is a scheme system (`base16`/`base24`/`tinted8`).
+fn dir_is_scheme_system(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.parse::<SchemeSystem>().is_ok())
+}
+
+/// Recursively collects scheme files. When `strict` is set (i.e. we are inside a scheme-system
+/// directory) an unrecognized file extension surfaces as an error; otherwise it is skipped.
+fn collect_scheme_files(
+    dirpath: impl AsRef<Path>,
+    glob_ignores: &[Glob],
+    is_recursive: bool,
+    strict: bool,
+) -> Result<Vec<SchemeFile>> {
     let mut scheme_paths: Vec<SchemeFile> = vec![];
 
     for item in dirpath.as_ref().read_dir()? {
         let file_path = item?.path();
-        // Skip hidden files and directories
-        if glob_ignores.iter().any(|g| g.is_match(file_path.as_path())) {
+
+        // Skip hidden files and directories (e.g. `.git`, `.github`, `.yamllint.yml`)
+        // as well as any caller-provided ignore globs.
+        let is_hidden = file_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with('.'));
+        if is_hidden || glob_ignores.iter().any(|g| g.is_match(file_path.as_path())) {
             continue;
         }
 
         if file_path.is_dir() && is_recursive {
-            let inner_scheme_paths_result = get_scheme_files(&file_path, ignores, true);
-
-            if let Ok(inner_scheme_paths) = inner_scheme_paths_result {
-                scheme_paths.extend(inner_scheme_paths);
-            }
+            let child_strict = strict || dir_is_scheme_system(&file_path);
+            scheme_paths.extend(collect_scheme_files(
+                &file_path,
+                glob_ignores,
+                true,
+                child_strict,
+            )?);
 
             continue;
         }
 
         // Only attempt to create a SchemeFile for regular files
         if file_path.is_file() {
-            let scheme_file_type_result = SchemeFile::new(&file_path);
-
-            match scheme_file_type_result {
+            match SchemeFile::new(&file_path) {
                 Ok(scheme_file_type) => scheme_paths.push(scheme_file_type),
-                Err(err) => {
-                    // Be strict: surface invalid scheme files as intake errors
-                    return Err(err);
-                }
+                // Inside a scheme-system directory, be strict: surface invalid files as
+                // intake errors. Elsewhere, the file simply isn't a scheme - skip it.
+                Err(err) if strict => return Err(err),
+                Err(_) => {}
             }
         }
     }
@@ -218,6 +252,47 @@ pub fn get_scheme_files(
     scheme_paths.sort_by_key(SchemeFile::get_path);
 
     Ok(scheme_paths)
+}
+
+/// Collects scheme files from a `<system>/`-organized schemes directory.
+///
+/// Walks the `base16`/`base24`/`tinted8` subdirectories (the layout of the
+/// `tinted-theming/schemes` repository) and returns a map keyed by `<system>-<file-stem>`
+/// (e.g. `base16-github`). Discovery is strict within each scheme-system directory, so an
+/// unrecognized file there surfaces an error; files at the schemes-directory root are ignored.
+///
+/// When `scheme_system` is `Some`, only that system's subdirectory is walked. Missing
+/// subdirectories are skipped rather than treated as errors.
+///
+/// # Errors
+///
+/// Returns an error if a scheme-system subdirectory cannot be read, or if it contains a file
+/// with an unrecognized extension.
+// Public library API consumed by downstreams (e.g. tinty); unused by this crate's own binary.
+#[allow(dead_code)]
+pub fn get_scheme_files_by_name(
+    schemes_path: impl AsRef<Path>,
+    scheme_system: Option<SchemeSystem>,
+) -> Result<HashMap<String, SchemeFile>> {
+    let scheme_systems =
+        scheme_system.map_or_else(|| SchemeSystem::variants().to_vec(), |system| vec![system]);
+
+    let mut scheme_files: HashMap<String, SchemeFile> = HashMap::new();
+    for scheme_system in scheme_systems {
+        let scheme_system_dir = schemes_path.as_ref().join(scheme_system.as_str());
+        if !scheme_system_dir.is_dir() {
+            continue;
+        }
+
+        // The directory name is a scheme system, so `get_scheme_files` walks it strictly.
+        for scheme_file in get_scheme_files(&scheme_system_dir, &[], false)? {
+            if let Some(stem) = scheme_file.get_path().file_stem().and_then(|s| s.to_str()) {
+                scheme_files.insert(format!("{scheme_system}-{stem}"), scheme_file);
+            }
+        }
+    }
+
+    Ok(scheme_files)
 }
 
 /// Parses a given file path into its directory, filestem, and optional extension.

--- a/tinted-builder-rust/tests/build_flow.rs
+++ b/tinted-builder-rust/tests/build_flow.rs
@@ -292,8 +292,10 @@ default:
 }
 
 #[test]
-fn e111_invalid_extension_in_schemes() -> Result<()> {
-    let tmp_dir = unique_tmp_dir("e111")?;
+fn non_scheme_files_at_root_are_ignored() -> Result<()> {
+    // The schemes-dir root may contain non-scheme files (e.g. `LICENSE`, `README.md`).
+    // These must be skipped during discovery rather than surfacing an E111 error.
+    let tmp_dir = unique_tmp_dir("non_scheme_root")?;
     let schemes = tmp_dir.join("schemes");
     let template = tmp_dir.join("template");
     let templates_dir = template.join("templates");
@@ -308,14 +310,15 @@ default:
 
     create_dir_all(&schemes)?;
     write_to_file(schemes.join("bad.txt"), "not a scheme")?;
+    write_to_file(schemes.join("LICENSE"), "license text")?;
+    write_to_file(schemes.join("README.md"), "# readme")?;
     create_dir_all(&templates_dir)?;
     write_to_file(templates_dir.join("config.yaml"), config)?;
     write_to_file(templates_dir.join("default.mustache"), "Hello\n")?;
 
-    #[allow(clippy::unwrap_used)]
-    let err = tinted_builder_rust::build(&template, &schemes, &[], true).unwrap_err();
+    // No schemes are present, but discovery must not fail on the non-scheme files.
+    tinted_builder_rust::build(&template, &schemes, &[], true)?;
 
-    assert!(err.to_string().contains("E111"));
     Ok(())
 }
 
@@ -471,5 +474,118 @@ default:
     let out = fs::read_to_string(&out_path)?;
 
     assert!(out.contains("Hello Test\nBlue is #0000ff"));
+    Ok(())
+}
+
+#[test]
+fn get_scheme_files_skips_non_scheme_and_hidden_files() -> Result<()> {
+    use tinted_builder_rust::operation_build::utils::get_scheme_files;
+
+    let tmp_dir = unique_tmp_dir("walker_lenient")?;
+    let schemes = tmp_dir.join("schemes");
+    create_dir_all(&schemes)?;
+
+    // Scheme files at the root are discovered...
+    write_to_file(schemes.join("good.yaml"), "x")?;
+    write_to_file(schemes.join("note.yml"), "x")?;
+    // ...while non-scheme files and hidden entries are skipped.
+    write_to_file(schemes.join("LICENSE"), "x")?;
+    write_to_file(schemes.join("README.md"), "x")?;
+    write_to_file(schemes.join(".yamllint.yml"), "x")?;
+    create_dir_all(schemes.join(".github").join("workflows"))?;
+    write_to_file(schemes.join(".github").join("workflows").join("ci.yml"), "x")?;
+
+    let files = get_scheme_files(&schemes, &[], true)?;
+    let mut names: Vec<String> = files
+        .iter()
+        .filter_map(|f| f.get_path().file_name()?.to_str().map(String::from))
+        .collect();
+    names.sort();
+
+    assert_eq!(names, vec!["good.yaml".to_string(), "note.yml".to_string()]);
+    Ok(())
+}
+
+#[test]
+fn get_scheme_files_is_strict_within_scheme_system_dir() -> Result<()> {
+    use tinted_builder_rust::operation_build::utils::get_scheme_files;
+
+    let tmp_dir = unique_tmp_dir("walker_strict")?;
+    let schemes = tmp_dir.join("schemes");
+    let base16 = schemes.join("base16");
+    create_dir_all(&base16)?;
+
+    // An unrecognized file directly inside a scheme-system directory must surface an error...
+    write_to_file(base16.join("not-a-scheme.txt"), "x")?;
+    #[allow(clippy::unwrap_used)]
+    let err = get_scheme_files(&schemes, &[], true).unwrap_err();
+    assert!(err.to_string().contains("E111"), "got: {err}");
+
+    // ...whereas the same file at the lenient root is simply skipped.
+    let tmp_dir = unique_tmp_dir("walker_strict_root")?;
+    let schemes = tmp_dir.join("schemes");
+    create_dir_all(&schemes)?;
+    write_to_file(schemes.join("not-a-scheme.txt"), "x")?;
+    assert!(get_scheme_files(&schemes, &[], true)?.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn get_scheme_files_by_name_keys_and_filters_by_system() -> Result<()> {
+    use tinted_builder::SchemeSystem;
+    use tinted_builder_rust::operation_build::utils::get_scheme_files_by_name;
+
+    let tmp_dir = unique_tmp_dir("walker_by_name")?;
+    let schemes = tmp_dir.join("schemes");
+    create_dir_all(schemes.join("base16"))?;
+    create_dir_all(schemes.join("base24"))?;
+    write_to_file(schemes.join("base16").join("github.yaml"), "x")?;
+    write_to_file(schemes.join("base24").join("dracula.yaml"), "x")?;
+    // Root-level files are not part of the `<system>/`-keyed map.
+    write_to_file(schemes.join("LICENSE"), "x")?;
+    write_to_file(schemes.join("boo-base16.yaml"), "x")?;
+
+    let all = get_scheme_files_by_name(&schemes, None)?;
+    assert_eq!(all.len(), 2);
+    assert!(all.contains_key("base16-github"));
+    assert!(all.contains_key("base24-dracula"));
+
+    let only_base16 = get_scheme_files_by_name(&schemes, Some(SchemeSystem::Base16))?;
+    assert_eq!(only_base16.len(), 1);
+    assert!(only_base16.contains_key("base16-github"));
+
+    Ok(())
+}
+
+#[test]
+fn build_renders_system_dir_scheme_despite_root_junk() -> Result<()> {
+    // A full build against a `<system>/`-organized schemes dir succeeds even when the root
+    // carries non-scheme files and hidden non-scheme YAML.
+    let config = fs::read_to_string("./tests/fixtures/templates/base16-config.yaml")?;
+    let mustache = fs::read_to_string("./tests/fixtures/templates/base16-template.mustache")?;
+    let scheme = fs::read_to_string("./tests/fixtures/schemes/base16/silk-light.yaml")?;
+
+    let tmp_dir = unique_tmp_dir("build_with_junk")?;
+    let schemes = tmp_dir.join("schemes");
+    let template = tmp_dir.join("template");
+    let templates_dir = template.join("templates");
+
+    create_dir_all(schemes.join("base16"))?;
+    write_to_file(schemes.join("base16").join("silk-light.yaml"), &scheme)?;
+    write_to_file(schemes.join("LICENSE"), "license text")?;
+    create_dir_all(schemes.join(".github").join("workflows"))?;
+    write_to_file(schemes.join(".github").join("workflows").join("ci.yml"), "on: push")?;
+
+    create_dir_all(&templates_dir)?;
+    write_to_file(templates_dir.join("config.yaml"), &config)?;
+    write_to_file(templates_dir.join("base16-template.mustache"), &mustache)?;
+
+    tinted_builder_rust::build(&template, &schemes, &[], true)?;
+
+    let output_dir = template.join("output-themes");
+    let rendered_count = fs::read_dir(&output_dir)?.count();
+    assert_eq!(rendered_count, 1, "expected the base16 scheme to render");
+
     Ok(())
 }

--- a/tinted-builder-rust/tests/build_flow.rs
+++ b/tinted-builder-rust/tests/build_flow.rs
@@ -493,7 +493,10 @@ fn get_scheme_files_skips_non_scheme_and_hidden_files() -> Result<()> {
     write_to_file(schemes.join("README.md"), "x")?;
     write_to_file(schemes.join(".yamllint.yml"), "x")?;
     create_dir_all(schemes.join(".github").join("workflows"))?;
-    write_to_file(schemes.join(".github").join("workflows").join("ci.yml"), "x")?;
+    write_to_file(
+        schemes.join(".github").join("workflows").join("ci.yml"),
+        "x",
+    )?;
 
     let files = get_scheme_files(&schemes, &[], true)?;
     let mut names: Vec<String> = files
@@ -575,7 +578,10 @@ fn build_renders_system_dir_scheme_despite_root_junk() -> Result<()> {
     write_to_file(schemes.join("base16").join("silk-light.yaml"), &scheme)?;
     write_to_file(schemes.join("LICENSE"), "license text")?;
     create_dir_all(schemes.join(".github").join("workflows"))?;
-    write_to_file(schemes.join(".github").join("workflows").join("ci.yml"), "on: push")?;
+    write_to_file(
+        schemes.join(".github").join("workflows").join("ci.yml"),
+        "on: push",
+    )?;
 
     create_dir_all(&templates_dir)?;
     write_to_file(templates_dir.join("config.yaml"), &config)?;


### PR DESCRIPTION
## Root cause

Scheme discovery in `get_scheme_files` walks the schemes directory and calls `SchemeFile::new()` on each file, which returns `E111` for any unrecognized extension. Two earlier changes combined to make this fatal:

- It became **strict** — the first unrecognized file does `return Err(..)` rather than being skipped.
- Hidden-entry skipping was dropped in favor of caller-supplied `--ignore` globs.

So a caller that passes no ignores (the zero-config case) dies on the first non-scheme file in the schemes repo root.

## Fix

This restores lenient scheme discovery (the behavior that existed before the tinted8 work) and layers a directory-location rule on top so genuinely misplaced files inside a system directory are still caught.

`get_scheme_files` now discovers schemes with a directory-location model:

- **Skip hidden entries** again (`.git`, `.github`, `.yamllint.yml`, …), in addition to the existing `--ignore` globs.
- **Lenient at the root** (and any non-system directory): a file with an unrecognized extension simply isn't a scheme and is skipped. Root-level scheme files still build; `LICENSE`/`README.md` are ignored.
- **Strict within a `base16`/`base24`/`tinted8` directory**: an unrecognized file there surfaces an error. Recursion now propagates that error instead of silently discarding the whole directory.

Strictness is keyed off whether a directory's own name parses as a `SchemeSystem`, so it needs no new flags on the public signature.

## New public API

Adds `get_scheme_files_by_name()`, which walks a `<system>/`-organized schemes directory and returns a `HashMap` keyed by `<system>-<file-stem>` (e.g. `base16-github`), optionally filtered to one system. It's built on `get_scheme_files`, so discovery has a single implementation that downstreams (e.g. `tinty`, which currently maintains its own copy) can share.

## Compatibility

- Backwards compatible: flat schemes directories and the `--ignore` flag keep working. The only behavior change is that previously-fatal non-scheme files are now skipped (root) or reported with proper error propagation (inside a system dir).
- New public function ⇒ this warrants a minor version bump. I left the version and `CHANGELOG` headers for the release step.

## Tests

- Inverted the old `e111_invalid_extension_in_schemes` test — a non-scheme file at the schemes root must now be ignored, not fatal.
- Added coverage for: lenient root + hidden-entry skipping; strict-within a system directory (E111 surfaces); `get_scheme_files_by_name` keying and per-system filtering; and a full `build` against a schemes dir carrying root junk + `.github/**`.
- Full workspace suite green; `clippy` clean under the crate's `pedantic + nursery = deny`.
